### PR TITLE
Add Syft + Trivy extraction-only SBOM generation to the Voyager instrument

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,52 @@
+name: Deploy Docs
+
+# Docs source lives on `main` (docs/ + mkdocs.yml), edited in normal PRs.
+# On a docs change, build the site and deploy it straight to GitHub Pages as an
+# artifact — no gh-pages branch, no force-push.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:      # allow a manual redeploy from the Actions tab
+
+permissions:              # required by the Pages artifact deploy
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:              # a newer run supersedes an in-flight deploy
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Install MkDocs
+        run: pip install -r requirements-docs.txt
+      - name: Build (strict — fails on broken links or nav)
+        run: mkdocs build --strict --site-dir site
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,7 +6,9 @@ name: Deploy Docs
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - add-syft-trivy-extraction   # TEMP (testing): lets this branch publish. Remove before merge.
     paths:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,9 +6,7 @@ name: Deploy Docs
 
 on:
   push:
-    branches:
-      - main
-      - add-syft-trivy-extraction   # TEMP (testing): lets this branch publish. Remove before merge.
+    branches: [main]
     paths:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -38,7 +38,7 @@ jobs:
         run: pip install -r requirements-docs.txt
       - name: Build (strict — fails on broken links or nav)
         run: mkdocs build --strict --site-dir site
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -51,4 +51,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,12 @@ node_modules
 
 .regression-work/
 regression-report/
+
+# bundled syft/trivy binaries (downloaded at release time, or locally for testing)
+bin/syft-*
+bin/trivy-*
+!bin/syft-wrapper.*
+!bin/trivy-wrapper.*
+.trivy-cache/
+/depminer/
+depminer-voyager.zip

--- a/PREP_GUIDE.md
+++ b/PREP_GUIDE.md
@@ -1,0 +1,154 @@
+# Preparing your project for a complete scan
+
+This instrument scans **whatever technologies it finds** in your repositories — Java, Node,
+Python, Go, Rust, .NET, PHP, Ruby, and more — automatically, in a single pass. You do **not**
+tell it what stack you use; it detects everything present.
+
+The one thing it needs from you is that your project is in a **resolved** state on disk before
+we scan. Here is why, and the minimal steps to get there.
+
+---
+
+## Why any prep is needed at all
+
+Syft and Trivy are **static readers**. They do **not** build your project, run your package
+manager, or reach the internet (this instrument is 100% offline). They report exactly the
+dependencies that are already written down on disk:
+
+- A **lock file** (`package-lock.json`, `Cargo.lock`, `poetry.lock`, `gradle.lockfile`, …)
+  lists the **full transitive tree** — every direct *and* indirect dependency, pinned. When one
+  is present, the scan is complete with zero effort.
+- A bare **manifest** (`pom.xml`, `build.gradle`, a hand-written `requirements.txt`) lists only
+  the **direct** dependencies. Without a resolved lock file or a warm local cache, the scan sees
+  the direct deps only — the transitive tree is missing.
+
+So "prep" means one thing: **make the resolved state exist before we scan.** For most projects
+it already does.
+
+---
+
+## The 30-second version
+
+| Your stack | What to do |
+|---|---|
+| npm / yarn / pnpm, Go, Rust, Ruby, PHP, .NET, Python (Poetry / Pipenv / uv) | **Nothing** — just make sure the lock file is committed (it usually is). |
+| **Maven** | Run one command to warm the local cache — see [Maven](#maven). |
+| **Gradle** | Generate lock files once — see [Gradle](#gradle). |
+| Python with a bare `requirements.txt` | Regenerate it fully-pinned — see [Python](#python-bare-requirementstxt). |
+
+If your project is only in the first row, you are done. The rest of this file is for the three
+cases that need a one-time command.
+
+> **Do the prep on a machine that can build the project** (it needs your build tools, and for
+> the one-time resolve step, internet). The *scan itself* is always offline — prep and scan are
+> separate. See [Where prep must happen](#where-the-prep-must-happen) for the one important
+> detail about Maven.
+
+---
+
+## Maven
+
+A `pom.xml` does **not** store the resolved dependency tree — Maven normally rebuilds it by
+reaching Maven Central. Offline, we instead read your **local Maven cache** at
+`~/.m2/repository`. So the prep is to fill that cache once:
+
+```bash
+# In the project directory, on a machine with internet + Maven installed:
+mvn dependency:go-offline
+# (a normal build works too and is more thorough:)
+# mvn install -DskipTests
+```
+
+That downloads every dependency's metadata into `~/.m2/repository`. After that, both scanners
+resolve the **full transitive tree** from the cache — no network.
+
+**Measured effect** (Apache Zeppelin, offline): Maven components detected went from **~1000 →
+~2400 (Trivy)** and **~300 → ~4000 (Syft)** once `~/.m2` was warmed. Same repo, same scan, only
+difference is the cache.
+
+If your build machine already compiles this project regularly, `~/.m2` is **already warm** and
+you need to do nothing.
+
+## Gradle
+
+Gradle has no lock file by default. Generate one so the resolved tree lands in a file that
+travels inside the repo:
+
+```bash
+# One-time: enable dependency locking in build.gradle (or settings.gradle):
+#   dependencyLocking { lockAllConfigurations() }
+# Then, on a machine with internet:
+./gradlew dependencies --write-locks
+```
+
+This writes `gradle.lockfile` (per module). Commit it. Both scanners read it and report the
+full tree — and because it lives in the repo, it is portable (no cache needed at scan time).
+
+## Python (bare `requirements.txt`)
+
+A hand-written `requirements.txt` usually lists only direct dependencies. Regenerate a fully
+resolved one:
+
+```bash
+# Option A — pip-tools (does not install anything):
+pip-compile            # turns requirements.in / pyproject into a pinned requirements.txt
+
+# Option B — from a virtualenv where the app is already installed:
+pip freeze > requirements.txt
+```
+
+If you use **Poetry, Pipenv, or uv**, no prep is needed — commit `poetry.lock` /
+`Pipfile.lock` / `uv.lock` and you already have the full tree.
+
+## Everything else (npm, Go, Rust, .NET, PHP, Ruby …)
+
+No prep beyond having the lock file committed, which is normal practice:
+
+| Stack | Lock file that must be present |
+|---|---|
+| npm / yarn / pnpm | `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` |
+| Go (1.17+) | `go.mod` (+ `go.sum`) |
+| Rust | `Cargo.lock` |
+| .NET | `packages.lock.json` (enable NuGet lock files if absent) |
+| PHP | `composer.lock` |
+| Ruby | `Gemfile.lock` |
+
+If one is missing, run the ecosystem's install once (`npm ci`, `dotnet restore`, …) to create
+it, and commit it.
+
+---
+
+## Where the prep must happen
+
+There are two shapes of prep, and they differ in one important way:
+
+| Prep produces… | Lives in… | Portable? |
+|---|---|---|
+| A **lock file** (Gradle, npm, Python-lock, etc.) | a file **inside the repo** | ✅ Yes — prep anywhere, the file ships with the code |
+| A **warm cache** (Maven `~/.m2`) | the user's **home directory**, not the repo | ⚠️ No — see below |
+
+**Maven is the one to watch.** Its resolved data sits in `~/.m2` on whichever machine did the
+build, *not* in the repo. The scanners read the `~/.m2` of the machine **running the scan**. So
+for Maven, do one of:
+
+1. **Run the `mvn dependency:go-offline` and the scan on the same machine (same user home).**
+   Simplest, and automatic if the client scans on its own build box.
+2. Otherwise, carry the warmed `~/.m2` to the scan machine (or point the tools at a project-local
+   cache — Syft honors `SYFT_JAVA_MAVEN_LOCAL_REPOSITORY_DIR`).
+
+Lock-file ecosystems have no such constraint — the lock file travels with the repo.
+
+---
+
+## How to check it worked
+
+After prep, a quick sanity check: the number of Maven/other components in a scan should be much
+higher than "just the direct dependencies you wrote in the manifest." If a Maven project reports
+only a few dozen components, `~/.m2` was probably not warm on the scan machine.
+
+## What this cannot do
+
+The scanners find any technology **they support** (broad — essentially every mainstream
+ecosystem). A stack neither tool catalogs — e.g. Bazel, Scala SBT, Perl/CPAN — will not appear
+no matter how you prep, because there is no lock file or cache these tools know how to read for
+it. For the full supported-ecosystem list, see the tools' own documentation.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
 # DepMi (Dependency Miner)
+
+Depminer mines dependency information from a target folder of repositories. As a
+**Voyager instrument** it runs three tools per mission, side by side:
+
+| Command name (use exactly this in mission.yml) | Tool | Output in `depminer/results/` |
+|---|---|---|
+| `Mine Dependencies` | depminer | mined manifest files (`pom-*.xml`, `package-*.json`, …) + `index.json` |
+| `Syft SBOM` | Syft (bundled) | `<project>.syft.json`, `<project>.cdx.json`, `<project>.spdx.json` per project |
+| `Trivy Extract` | Trivy (bundled) | `<project>.trivy.cdx.json` per project |
+
+Syft and Trivy run **extraction-only and 100% offline**: no vulnerability databases,
+no telemetry, no version checks, no registry or Maven Central lookups. They only read
+the target folder and write SBOM files. Their binaries are bundled in `bin/` for
+linux/macOS (amd64 + arm64) and Windows (amd64) — nothing is downloaded at run time.
+
+**All three tools run by default.** No configuration is needed for the full run.
+
+## Choosing which tools run
+
+### Per mission — list only the commands you want
+
+```yaml
+mission: my-analysis
+target: /path/to/repos
+instruments:
+  depminer:
+    commands:
+      - Mine Dependencies
+      - Syft SBOM        # Trivy Extract not listed -> Trivy does not run
+```
+
+Command names must match the table above exactly. If `commands` is empty or missing,
+Voyager runs all three (see the mission.yml section of Voyager's own README; requires
+`runsAll: false` in the install's `.config.yml`, which voyenv-built bundles set).
+
+### Per environment variable — explicit on/off switches
+
+| Variable | Effect when set to `"false"` |
+|---|---|
+| `DEPMINER_RUN_MINER` | skip depminer's own extraction |
+| `DEPMINER_RUN_SYFT` | skip Syft |
+| `DEPMINER_RUN_TRIVY` | skip Trivy |
+
+Unset or any other value means ON. A skipped command still reports SUCCESS in the
+mission summary (it just logs that it was skipped). Set the variables in any of these
+places — later ones win:
+
+1. the shell that launches voyager (`DEPMINER_RUN_TRIVY=false ./voyager.sh mission.yml`)
+2. `.config.yml` in the voyager folder, under `environment:`
+3. `mission.yml` under `environment:` — **highest priority**, recommended for prod:
+
+```yaml
+environment:
+  DEPMINER_RUN_TRIVY: "false"
+```
+
+## Bundled tool versions
+
+| Tool | Version | Source |
+|---|---|---|
+| Syft | 1.46.0 | github.com/anchore/syft (pinned in `scripts/prepare-release-voyager.sh`) |
+| Trivy | 0.72.0 | github.com/aquasecurity/trivy (pinned in `scripts/prepare-release-voyager.sh`) |
+
+The wrappers in `bin/` pick the binary matching the host OS/arch and fall back to a
+tool on PATH only when no bundled binary exists (a development convenience — release
+bundles always contain the binaries).

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ environment:
   DEPMINER_RUN_TRIVY: "false"
 ```
 
+Two more switches control **Syft's offline Maven resolution** (see PREP_GUIDE.md), and
+accept the same three locations: `SYFT_JAVA_RESOLVE_TRANSITIVE_DEPENDENCIES` and
+`SYFT_JAVA_USE_MAVEN_LOCAL_REPOSITORY`. Both default to `"true"` (resolve the full
+transitive tree from the local `~/.m2` cache); set **both** to `"false"` to fall back to
+declared-only Maven results. Everything stays offline either way.
+
+## When one project fails to scan
+
+Syft and Trivy scan every project in the target even if one of them fails: the failing
+project is logged with a warning, the remaining projects still get their SBOMs, and the
+command finishes with a summary of failed projects. The command then reports as FAILED in
+the mission summary — check its log to see which projects were affected; all other result
+files are still written.
+
 ## Bundled tool versions
 
 | Tool | Version | Source |

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ linux/macOS (amd64 + arm64) and Windows (amd64) — nothing is downloaded at run
 
 **All three tools run by default.** No configuration is needed for the full run.
 
+## Getting complete results (transitive dependencies)
+
+Syft and Trivy read your project's **already-resolved** dependency state — lock files, or a
+warm local cache — they do **not** build your project. For most ecosystems the lock file is
+already committed and you need to do **nothing**. A few (Maven, Gradle, and a bare
+`requirements.txt`) need one minimal, one-time prep step first so the scan captures the full
+transitive tree instead of only the directly-declared dependencies.
+
+👉 **See [`PREP_GUIDE.md`](PREP_GUIDE.md) for the per-technology prep steps.**
+
 ## Choosing which tools run
 
 ### Per mission — list only the commands you want

--- a/bin/syft-wrapper.ps1
+++ b/bin/syft-wrapper.ps1
@@ -24,6 +24,10 @@ $env:SYFT_CHECK_FOR_APP_UPDATE = "false"
 $env:SYFT_GOLANG_SEARCH_REMOTE_LICENSES = "false"
 $env:SYFT_GOLANG_USE_PACKAGES_LIB = "false"
 $env:SYFT_JAVA_USE_NETWORK = "false"
+# Maven transitive deps, still offline: resolve the tree from ~/.m2 (BOTH required; still
+# offline because USE_NETWORK stays false). No-op unless ~/.m2 is populated - see PREP_GUIDE.md.
+$env:SYFT_JAVA_RESOLVE_TRANSITIVE_DEPENDENCIES = "true"
+$env:SYFT_JAVA_USE_MAVEN_LOCAL_REPOSITORY = "true"
 $env:SYFT_JAVASCRIPT_SEARCH_REMOTE_LICENSES = "false"
 $env:SYFT_PYTHON_SEARCH_REMOTE_LICENSES = "false"
 

--- a/bin/syft-wrapper.ps1
+++ b/bin/syft-wrapper.ps1
@@ -1,0 +1,51 @@
+<#
+    Voyager depminer instrument - Syft wrapper (Windows).
+    Extraction-only, 100% offline: every Syft network touchpoint is forced off here
+    (belt-and-braces with instrument.yml's environment block).
+    The instrument runs "once", so <target-path> holds all repositories: each
+    subdirectory is scanned as its own project; if there are none, the target itself is.
+    Usage: syft-wrapper.ps1 <target-path> <output-dir>
+#>
+param(
+    [Parameter(Mandatory = $true)][string]$Target,
+    [Parameter(Mandatory = $true)][string]$Out
+)
+$ErrorActionPreference = "Stop"
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+$env:SYFT_CHECK_FOR_APP_UPDATE = "false"
+$env:SYFT_GOLANG_SEARCH_REMOTE_LICENSES = "false"
+$env:SYFT_GOLANG_USE_PACKAGES_LIB = "false"
+$env:SYFT_JAVA_USE_NETWORK = "false"
+$env:SYFT_JAVASCRIPT_SEARCH_REMOTE_LICENSES = "false"
+$env:SYFT_PYTHON_SEARCH_REMOTE_LICENSES = "false"
+
+# Only windows amd64 is bundled (see scripts/prepare-release-voyager.sh).
+$bin = Join-Path $here "syft-windows-amd64.exe"
+if (-not (Test-Path $bin)) {
+    $onPath = Get-Command syft -ErrorAction SilentlyContinue
+    if ($onPath) { $bin = $onPath.Source }
+    else { Write-Error "no bundled 'syft-windows-amd64.exe' and no 'syft' on PATH"; exit 1 }
+}
+
+New-Item -ItemType Directory -Force -Path $Out | Out-Null
+Write-Host ">> syft: $bin"
+
+function Scan-One([string]$repo, [string]$name) {
+    Write-Host ">> syft scanning: $name"
+    & $bin scan "dir:$repo" `
+        -o "syft-json=$Out/$name.syft.json" `
+        -o "cyclonedx-json=$Out/$name.cdx.json" `
+        -o "spdx-json=$Out/$name.spdx.json" `
+        -q
+    if ($LASTEXITCODE -ne 0) { throw "syft failed for '$name' (exit $LASTEXITCODE)" }
+}
+
+$projects = Get-ChildItem -Path $Target -Directory -ErrorAction SilentlyContinue
+if ($projects -and $projects.Count -gt 0) {
+    foreach ($p in $projects) { Scan-One $p.FullName $p.Name }
+} else {
+    Scan-One $Target (Split-Path -Leaf $Target)
+}
+
+Write-Host ">> syft done -> $Out"

--- a/bin/syft-wrapper.ps1
+++ b/bin/syft-wrapper.ps1
@@ -26,8 +26,10 @@ $env:SYFT_GOLANG_USE_PACKAGES_LIB = "false"
 $env:SYFT_JAVA_USE_NETWORK = "false"
 # Maven transitive deps, still offline: resolve the tree from ~/.m2 (BOTH required; still
 # offline because USE_NETWORK stays false). No-op unless ~/.m2 is populated - see PREP_GUIDE.md.
-$env:SYFT_JAVA_RESOLVE_TRANSITIVE_DEPENDENCIES = "true"
-$env:SYFT_JAVA_USE_MAVEN_LOCAL_REPOSITORY = "true"
+# Default-on but overridable: set them to "false" in mission.yml / .config.yml / the host
+# shell to skip local-repo resolution (e.g. if it is ever pathologically slow).
+if (-not $env:SYFT_JAVA_RESOLVE_TRANSITIVE_DEPENDENCIES) { $env:SYFT_JAVA_RESOLVE_TRANSITIVE_DEPENDENCIES = "true" }
+if (-not $env:SYFT_JAVA_USE_MAVEN_LOCAL_REPOSITORY) { $env:SYFT_JAVA_USE_MAVEN_LOCAL_REPOSITORY = "true" }
 $env:SYFT_JAVASCRIPT_SEARCH_REMOTE_LICENSES = "false"
 $env:SYFT_PYTHON_SEARCH_REMOTE_LICENSES = "false"
 
@@ -52,11 +54,29 @@ function Scan-One([string]$repo, [string]$name) {
     if ($LASTEXITCODE -ne 0) { throw "syft failed for '$name' (exit $LASTEXITCODE)" }
 }
 
+# One failing project must not cost the others their SBOMs: log it, keep going,
+# report all failures at the end (the command then still fails in the mission summary).
+$failed = @()
 $projects = Get-ChildItem -Path $Target -Directory -ErrorAction SilentlyContinue
 if ($projects -and $projects.Count -gt 0) {
-    foreach ($p in $projects) { Scan-One $p.FullName $p.Name }
+    foreach ($p in $projects) {
+        try { Scan-One $p.FullName $p.Name }
+        catch {
+            Write-Host ">> WARN: $_ - continuing with remaining projects"
+            $failed += $p.Name
+        }
+    }
 } else {
-    Scan-One $Target (Split-Path -Leaf $Target)
+    $name = Split-Path -Leaf $Target
+    try { Scan-One $Target $name }
+    catch {
+        Write-Host ">> WARN: $_"
+        $failed += $name
+    }
 }
 
+if ($failed.Count -gt 0) {
+    Write-Host ">> syft done with $($failed.Count) failed project(s): $($failed -join ', ') -> $Out"
+    exit 1
+}
 Write-Host ">> syft done -> $Out"

--- a/bin/syft-wrapper.ps1
+++ b/bin/syft-wrapper.ps1
@@ -11,6 +11,13 @@ param(
     [Parameter(Mandatory = $true)][string]$Out
 )
 $ErrorActionPreference = "Stop"
+
+# Tool switch: ON unless explicitly disabled (see instrument.yml / README)
+if ($env:DEPMINER_RUN_SYFT -eq "false") {
+    Write-Host ">> Syft disabled (DEPMINER_RUN_SYFT=false) - skipping"
+    exit 0
+}
+
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 $env:SYFT_CHECK_FOR_APP_UPDATE = "false"

--- a/bin/syft-wrapper.sh
+++ b/bin/syft-wrapper.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Voyager depminer instrument — Syft wrapper (unix).
+# Extraction-only, 100% offline: every Syft network touchpoint is forced off here
+# (belt-and-braces with instrument.yml's environment block, so the wrapper is also
+# safe when run standalone outside Voyager).
+# The instrument runs "once", so <target-path> holds all repositories: each immediate
+# subdirectory is scanned as its own project; if there are none, the target itself is.
+# Usage: syft-wrapper.sh <target-path> <output-dir>
+set -euo pipefail
+
+TARGET="${1:?target path required}"
+OUT="${2:?output dir required}"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+export SYFT_CHECK_FOR_APP_UPDATE=false
+export SYFT_GOLANG_SEARCH_REMOTE_LICENSES=false
+export SYFT_GOLANG_USE_PACKAGES_LIB=false
+export SYFT_JAVA_USE_NETWORK=false
+export SYFT_JAVASCRIPT_SEARCH_REMOTE_LICENSES=false
+export SYFT_PYTHON_SEARCH_REMOTE_LICENSES=false
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+arch="$(uname -m)"
+case "$arch" in
+  x86_64|amd64)   arch="amd64" ;;
+  aarch64|arm64)  arch="arm64" ;;
+esac
+case "$os" in
+  darwin) os="darwin" ;;
+  *)      os="linux"  ;;
+esac
+
+BIN="${HERE}/syft-${os}-${arch}"
+
+# Some unzip implementations (e.g. voyenv's) drop unix exec bits — restore ours.
+if [[ -f "$BIN" && ! -x "$BIN" ]]; then
+  chmod +x "$BIN" 2>/dev/null || true
+fi
+
+if [[ ! -x "$BIN" ]]; then
+  if command -v syft >/dev/null 2>&1; then
+    BIN="$(command -v syft)"
+  else
+    echo "ERROR: no bundled binary 'syft-${os}-${arch}' and no 'syft' on PATH" >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$OUT"
+echo ">> syft: $BIN"
+
+scan_one() {
+  local repo="$1" name="$2"
+  echo ">> syft scanning: ${name}"
+  "$BIN" scan "dir:${repo}" \
+    -o "syft-json=${OUT}/${name}.syft.json" \
+    -o "cyclonedx-json=${OUT}/${name}.cdx.json" \
+    -o "spdx-json=${OUT}/${name}.spdx.json" \
+    -q
+}
+
+found=0
+for d in "$TARGET"/*/; do
+  [[ -d "$d" ]] || continue
+  found=1
+  scan_one "${d%/}" "$(basename "${d%/}")"
+done
+if [[ $found -eq 0 ]]; then
+  scan_one "$TARGET" "$(basename "$TARGET")"
+fi
+
+echo ">> syft done -> ${OUT}"

--- a/bin/syft-wrapper.sh
+++ b/bin/syft-wrapper.sh
@@ -11,6 +11,12 @@ set -euo pipefail
 TARGET="${1:?target path required}"
 OUT="${2:?output dir required}"
 
+# Tool switch: ON unless explicitly disabled (see instrument.yml / README)
+if [ "${DEPMINER_RUN_SYFT:-true}" = "false" ]; then
+  echo ">> Syft disabled (DEPMINER_RUN_SYFT=false) - skipping"
+  exit 0
+fi
+
 HERE="$(cd "$(dirname "$0")" && pwd)"
 
 export SYFT_CHECK_FOR_APP_UPDATE=false

--- a/bin/syft-wrapper.sh
+++ b/bin/syft-wrapper.sh
@@ -23,6 +23,10 @@ export SYFT_CHECK_FOR_APP_UPDATE=false
 export SYFT_GOLANG_SEARCH_REMOTE_LICENSES=false
 export SYFT_GOLANG_USE_PACKAGES_LIB=false
 export SYFT_JAVA_USE_NETWORK=false
+# Maven transitive deps, still offline: resolve the tree from ~/.m2 (BOTH required; still
+# offline because USE_NETWORK stays false). No-op unless ~/.m2 is populated — see PREP_GUIDE.md.
+export SYFT_JAVA_RESOLVE_TRANSITIVE_DEPENDENCIES=true
+export SYFT_JAVA_USE_MAVEN_LOCAL_REPOSITORY=true
 export SYFT_JAVASCRIPT_SEARCH_REMOTE_LICENSES=false
 export SYFT_PYTHON_SEARCH_REMOTE_LICENSES=false
 

--- a/bin/syft-wrapper.sh
+++ b/bin/syft-wrapper.sh
@@ -25,8 +25,10 @@ export SYFT_GOLANG_USE_PACKAGES_LIB=false
 export SYFT_JAVA_USE_NETWORK=false
 # Maven transitive deps, still offline: resolve the tree from ~/.m2 (BOTH required; still
 # offline because USE_NETWORK stays false). No-op unless ~/.m2 is populated — see PREP_GUIDE.md.
-export SYFT_JAVA_RESOLVE_TRANSITIVE_DEPENDENCIES=true
-export SYFT_JAVA_USE_MAVEN_LOCAL_REPOSITORY=true
+# Default-on but overridable: set them to "false" in mission.yml / .config.yml / the host
+# shell to skip local-repo resolution (e.g. if it is ever pathologically slow).
+export SYFT_JAVA_RESOLVE_TRANSITIVE_DEPENDENCIES="${SYFT_JAVA_RESOLVE_TRANSITIVE_DEPENDENCIES:-true}"
+export SYFT_JAVA_USE_MAVEN_LOCAL_REPOSITORY="${SYFT_JAVA_USE_MAVEN_LOCAL_REPOSITORY:-true}"
 export SYFT_JAVASCRIPT_SEARCH_REMOTE_LICENSES=false
 export SYFT_PYTHON_SEARCH_REMOTE_LICENSES=false
 
@@ -70,14 +72,34 @@ scan_one() {
     -q
 }
 
+# One failing project must not cost the others their SBOMs: log it, keep going,
+# report all failures at the end (the command then still fails in the mission summary).
 found=0
+fail_count=0
+fail_names=""
 for d in "$TARGET"/*/; do
   [[ -d "$d" ]] || continue
   found=1
-  scan_one "${d%/}" "$(basename "${d%/}")"
+  name="$(basename "${d%/}")"
+  scan_one "${d%/}" "$name" || {
+    rc=$?
+    echo ">> WARN: syft failed for '${name}' (exit ${rc}) - continuing with remaining projects" >&2
+    fail_count=$((fail_count + 1))
+    fail_names="${fail_names} ${name}"
+  }
 done
 if [[ $found -eq 0 ]]; then
-  scan_one "$TARGET" "$(basename "$TARGET")"
+  name="$(basename "$TARGET")"
+  scan_one "$TARGET" "$name" || {
+    rc=$?
+    echo ">> WARN: syft failed for '${name}' (exit ${rc})" >&2
+    fail_count=1
+    fail_names=" ${name}"
+  }
 fi
 
+if [[ $fail_count -gt 0 ]]; then
+  echo ">> syft done with ${fail_count} failed project(s):${fail_names} -> ${OUT}" >&2
+  exit 1
+fi
 echo ">> syft done -> ${OUT}"

--- a/bin/trivy-wrapper.ps1
+++ b/bin/trivy-wrapper.ps1
@@ -12,6 +12,13 @@ param(
     [Parameter(Mandatory = $true)][string]$Out
 )
 $ErrorActionPreference = "Stop"
+
+# Tool switch: ON unless explicitly disabled (see instrument.yml / README)
+if ($env:DEPMINER_RUN_TRIVY -eq "false") {
+    Write-Host ">> Trivy disabled (DEPMINER_RUN_TRIVY=false) - skipping"
+    exit 0
+}
+
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $cache = Join-Path (Split-Path -Parent $here) ".trivy-cache"   # stays empty in this mode
 

--- a/bin/trivy-wrapper.ps1
+++ b/bin/trivy-wrapper.ps1
@@ -1,0 +1,51 @@
+<#
+    Voyager depminer instrument - Trivy wrapper (Windows).
+    Extraction-only, 100% offline: SBOM formats disable Trivy's security scanning,
+    --offline-scan blocks Maven Central lookups, and telemetry/version-check/DB
+    updates are all forced off. No network call is ever attempted.
+    The instrument runs "once", so <target-path> holds all repositories: each
+    subdirectory is scanned as its own project; if there are none, the target itself is.
+    Usage: trivy-wrapper.ps1 <target-path> <output-dir>
+#>
+param(
+    [Parameter(Mandatory = $true)][string]$Target,
+    [Parameter(Mandatory = $true)][string]$Out
+)
+$ErrorActionPreference = "Stop"
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$cache = Join-Path (Split-Path -Parent $here) ".trivy-cache"   # stays empty in this mode
+
+# Only windows amd64 is bundled (Trivy publishes no windows-arm64 build).
+$bin = Join-Path $here "trivy-windows-amd64.exe"
+if (-not (Test-Path $bin)) {
+    $onPath = Get-Command trivy -ErrorAction SilentlyContinue
+    if ($onPath) { $bin = $onPath.Source }
+    else { Write-Error "no bundled 'trivy-windows-amd64.exe' and no 'trivy' on PATH"; exit 1 }
+}
+
+New-Item -ItemType Directory -Force -Path $Out | Out-Null
+New-Item -ItemType Directory -Force -Path $cache | Out-Null
+Write-Host ">> trivy: $bin"
+
+function Scan-One([string]$repo, [string]$name) {
+    Write-Host ">> trivy scanning: $name"
+    & $bin fs `
+        --cache-dir $cache `
+        --offline-scan `
+        --skip-db-update --skip-java-db-update `
+        --disable-telemetry --skip-version-check `
+        --format cyclonedx `
+        --output "$Out/$name.trivy.cdx.json" `
+        --quiet `
+        $repo
+    if ($LASTEXITCODE -ne 0) { throw "trivy failed for '$name' (exit $LASTEXITCODE)" }
+}
+
+$projects = Get-ChildItem -Path $Target -Directory -ErrorAction SilentlyContinue
+if ($projects -and $projects.Count -gt 0) {
+    foreach ($p in $projects) { Scan-One $p.FullName $p.Name }
+} else {
+    Scan-One $Target (Split-Path -Leaf $Target)
+}
+
+Write-Host ">> trivy done -> $Out"

--- a/bin/trivy-wrapper.ps1
+++ b/bin/trivy-wrapper.ps1
@@ -48,11 +48,29 @@ function Scan-One([string]$repo, [string]$name) {
     if ($LASTEXITCODE -ne 0) { throw "trivy failed for '$name' (exit $LASTEXITCODE)" }
 }
 
+# One failing project must not cost the others their SBOMs: log it, keep going,
+# report all failures at the end (the command then still fails in the mission summary).
+$failed = @()
 $projects = Get-ChildItem -Path $Target -Directory -ErrorAction SilentlyContinue
 if ($projects -and $projects.Count -gt 0) {
-    foreach ($p in $projects) { Scan-One $p.FullName $p.Name }
+    foreach ($p in $projects) {
+        try { Scan-One $p.FullName $p.Name }
+        catch {
+            Write-Host ">> WARN: $_ - continuing with remaining projects"
+            $failed += $p.Name
+        }
+    }
 } else {
-    Scan-One $Target (Split-Path -Leaf $Target)
+    $name = Split-Path -Leaf $Target
+    try { Scan-One $Target $name }
+    catch {
+        Write-Host ">> WARN: $_"
+        $failed += $name
+    }
 }
 
+if ($failed.Count -gt 0) {
+    Write-Host ">> trivy done with $($failed.Count) failed project(s): $($failed -join ', ') -> $Out"
+    exit 1
+}
 Write-Host ">> trivy done -> $Out"

--- a/bin/trivy-wrapper.sh
+++ b/bin/trivy-wrapper.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Voyager depminer instrument — Trivy wrapper (unix).
+# Extraction-only, 100% offline: SBOM formats disable Trivy's security scanning,
+# --offline-scan blocks Maven Central lookups, and telemetry/version-check/DB
+# updates are all forced off. No network call is ever attempted.
+# The instrument runs "once", so <target-path> holds all repositories: each immediate
+# subdirectory is scanned as its own project; if there are none, the target itself is.
+# Usage: trivy-wrapper.sh <target-path> <output-dir>
+set -euo pipefail
+
+TARGET="${1:?target path required}"
+OUT="${2:?output dir required}"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CACHE="${HERE}/../.trivy-cache"   # stays empty in this mode; kept out of results/
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+arch="$(uname -m)"
+case "$arch" in
+  x86_64|amd64)   arch="amd64" ;;
+  aarch64|arm64)  arch="arm64" ;;
+esac
+case "$os" in
+  darwin) os="darwin" ;;
+  *)      os="linux"  ;;
+esac
+
+BIN="${HERE}/trivy-${os}-${arch}"
+
+# Some unzip implementations (e.g. voyenv's) drop unix exec bits — restore ours.
+if [[ -f "$BIN" && ! -x "$BIN" ]]; then
+  chmod +x "$BIN" 2>/dev/null || true
+fi
+
+if [[ ! -x "$BIN" ]]; then
+  if command -v trivy >/dev/null 2>&1; then
+    BIN="$(command -v trivy)"
+  else
+    echo "ERROR: no bundled binary 'trivy-${os}-${arch}' and no 'trivy' on PATH" >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$OUT" "$CACHE"
+echo ">> trivy: $BIN"
+
+scan_one() {
+  local repo="$1" name="$2"
+  echo ">> trivy scanning: ${name}"
+  "$BIN" fs \
+    --cache-dir "$CACHE" \
+    --offline-scan \
+    --skip-db-update --skip-java-db-update \
+    --disable-telemetry --skip-version-check \
+    --format cyclonedx \
+    --output "${OUT}/${name}.trivy.cdx.json" \
+    --quiet \
+    "$repo"
+}
+
+found=0
+for d in "$TARGET"/*/; do
+  [[ -d "$d" ]] || continue
+  found=1
+  scan_one "${d%/}" "$(basename "${d%/}")"
+done
+if [[ $found -eq 0 ]]; then
+  scan_one "$TARGET" "$(basename "$TARGET")"
+fi
+
+echo ">> trivy done -> ${OUT}"

--- a/bin/trivy-wrapper.sh
+++ b/bin/trivy-wrapper.sh
@@ -11,6 +11,12 @@ set -euo pipefail
 TARGET="${1:?target path required}"
 OUT="${2:?output dir required}"
 
+# Tool switch: ON unless explicitly disabled (see instrument.yml / README)
+if [ "${DEPMINER_RUN_TRIVY:-true}" = "false" ]; then
+  echo ">> Trivy disabled (DEPMINER_RUN_TRIVY=false) - skipping"
+  exit 0
+fi
+
 HERE="$(cd "$(dirname "$0")" && pwd)"
 CACHE="${HERE}/../.trivy-cache"   # stays empty in this mode; kept out of results/
 

--- a/bin/trivy-wrapper.sh
+++ b/bin/trivy-wrapper.sh
@@ -64,14 +64,34 @@ scan_one() {
     "$repo"
 }
 
+# One failing project must not cost the others their SBOMs: log it, keep going,
+# report all failures at the end (the command then still fails in the mission summary).
 found=0
+fail_count=0
+fail_names=""
 for d in "$TARGET"/*/; do
   [[ -d "$d" ]] || continue
   found=1
-  scan_one "${d%/}" "$(basename "${d%/}")"
+  name="$(basename "${d%/}")"
+  scan_one "${d%/}" "$name" || {
+    rc=$?
+    echo ">> WARN: trivy failed for '${name}' (exit ${rc}) - continuing with remaining projects" >&2
+    fail_count=$((fail_count + 1))
+    fail_names="${fail_names} ${name}"
+  }
 done
 if [[ $found -eq 0 ]]; then
-  scan_one "$TARGET" "$(basename "$TARGET")"
+  name="$(basename "$TARGET")"
+  scan_one "$TARGET" "$name" || {
+    rc=$?
+    echo ">> WARN: trivy failed for '${name}' (exit ${rc})" >&2
+    fail_count=1
+    fail_names=" ${name}"
+  }
 fi
 
+if [[ $fail_count -gt 0 ]]; then
+  echo ">> trivy done with ${fail_count} failed project(s):${fail_names} -> ${OUT}" >&2
+  exit 1
+fi
 echo ">> trivy done -> ${OUT}"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,70 @@
+# Configuration
+
+All three tools run by default — you only need this page when you want to **turn some off** or tune
+Syft's offline Maven resolution.
+
+## Choosing which tools run
+
+### Per mission — list only the commands you want
+
+```yaml
+mission: my-analysis
+target: /path/to/repos
+instruments:
+  depminer:
+    commands:
+      - Mine Dependencies
+      - Syft SBOM        # Trivy Extract not listed -> Trivy does not run
+```
+
+Command names must match [the command table](index.md) exactly. If `commands` is empty or missing,
+Voyager runs all three (requires `runsAll: false` in the install's `.config.yml`, which
+voyenv-built bundles set).
+
+### Per environment variable — explicit on/off switches
+
+| Variable | Effect when set to `"false"` |
+|---|---|
+| `DEPMINER_RUN_MINER` | skip depminer's own extraction |
+| `DEPMINER_RUN_SYFT` | skip Syft |
+| `DEPMINER_RUN_TRIVY` | skip Trivy |
+
+Unset or any other value means **ON**. A skipped command still reports SUCCESS in the mission
+summary (it just logs that it was skipped).
+
+Set the variables in any of these places — **later ones win**:
+
+1. the shell that launches voyager (`DEPMINER_RUN_TRIVY=false ./voyager.sh mission.yml`)
+2. `.config.yml` in the voyager folder, under `environment:`
+3. `mission.yml` under `environment:` — **highest priority**, recommended for prod:
+
+```yaml
+environment:
+  DEPMINER_RUN_TRIVY: "false"
+```
+
+## Syft offline Maven resolution
+
+Two more switches control Syft's offline Maven resolution (see
+[Preparing Your Project → Maven](prep-guide.md#maven)). They accept the same three locations and
+precedence as above:
+
+| Variable | Default | Set to `"false"` to… |
+|---|---|---|
+| `SYFT_JAVA_RESOLVE_TRANSITIVE_DEPENDENCIES` | `"true"` | stop resolving the transitive tree |
+| `SYFT_JAVA_USE_MAVEN_LOCAL_REPOSITORY` | `"true"` | stop reading the local `~/.m2` cache |
+
+Both default to `"true"` — resolve the full transitive tree from the local `~/.m2` cache. Set
+**both** to `"false"` to fall back to declared-only Maven results. Everything stays offline either
+way.
+
+## When one project fails to scan
+
+Syft and Trivy scan every project in the target even if one of them fails:
+
+- the failing project is logged with a warning,
+- the remaining projects still get their SBOMs,
+- the command finishes with a summary of failed projects.
+
+The command then reports as **FAILED** in the mission summary — check its log to see which projects
+were affected. All other result files are still written.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,43 @@
+# DepMiner
+
+**DepMiner (DepMi)** mines dependency information from a target folder of repositories.
+As a **Voyager instrument** it runs three tools per mission, side by side:
+
+| Command name (use exactly this in `mission.yml`) | Tool | Output in `depminer/results/` |
+|---|---|---|
+| `Mine Dependencies` | depminer | mined manifest files (`pom-*.xml`, `package-*.json`, …) + `index.json` |
+| `Syft SBOM` | Syft (bundled) | `<project>.syft.json`, `<project>.cdx.json`, `<project>.spdx.json` per project |
+| `Trivy Extract` | Trivy (bundled) | `<project>.trivy.cdx.json` per project |
+
+Syft and Trivy run **extraction-only and 100% offline**: no vulnerability databases, no
+telemetry, no version checks, no registry or Maven Central lookups. They only read the target
+folder and write SBOM files. Their binaries are bundled in `bin/` for linux/macOS
+(amd64 + arm64) and Windows (amd64) — nothing is downloaded at run time.
+
+!!! tip "All three tools run by default"
+    No configuration is needed for the full run. Point it at a folder of repositories and you get
+    mined manifests plus three SBOM formats per project.
+
+## Where to go next
+
+<div class="grid cards" markdown>
+
+- :material-rocket-launch: **[Quick Start](quickstart.md)** — run DepMiner as a Voyager instrument and find your results.
+- :material-wrench: **[Preparing Your Project](prep-guide.md)** — the one-time step some ecosystems need for a *complete* (transitive) scan.
+- :material-tune: **[Configuration](configuration.md)** — choose which tools run, per mission or per environment variable.
+- :material-package-variant: **[Bundled Tools](tools.md)** — pinned Syft/Trivy versions and the offline guarantees.
+
+</div>
+
+## What it produces
+
+For every project it finds in the target folder, DepMiner writes results under
+`depminer/results/`:
+
+- **Mined manifests** — the raw dependency declarations depminer extracts, plus an `index.json`.
+- **Syft SBOMs** — three formats per project: native Syft JSON, CycloneDX (`.cdx.json`), and SPDX.
+- **Trivy SBOM** — CycloneDX per project (`.trivy.cdx.json`).
+
+Because Syft and Trivy read your project's **already-resolved** dependency state rather than
+building it, most ecosystems need zero setup. A few (Maven, Gradle, a bare `requirements.txt`)
+need one minimal, one-time prep step — see [Preparing Your Project](prep-guide.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 **DepMiner (DepMi)** mines dependency information from a target folder of repositories.
 As a **Voyager instrument** it runs three tools per mission, side by side:
 
-| Command name (use exactly this in `mission.yml`) | Tool | Output in `depminer/results/` |
+| Command name (use exactly this in `mission.yml`) | Tool | Output (in `depminer/results/` inside the results zip) |
 |---|---|---|
 | `Mine Dependencies` | depminer | mined manifest files (`pom-*.xml`, `package-*.json`, …) + `index.json` |
 | `Syft SBOM` | Syft (bundled) | `<project>.syft.json`, `<project>.cdx.json`, `<project>.spdx.json` per project |
@@ -31,8 +31,9 @@ folder and write SBOM files. Their binaries are bundled in `bin/` for linux/macO
 
 ## What it produces
 
-For every project it finds in the target folder, DepMiner writes results under
-`depminer/results/`:
+For every project it finds in the target folder, DepMiner produces the following, delivered inside
+the run's results zip (`<mission>-voyager-results.zip`, under `depminer/results/` — see
+[Quick Start → Find your results](quickstart.md#3-find-your-results)):
 
 - **Mined manifests** — the raw dependency declarations depminer extracts, plus an `index.json`.
 - **Syft SBOMs** — three formats per project: native Syft JSON, CycloneDX (`.cdx.json`), and SPDX.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,96 @@
+# Installing
+
+[Quick Start](quickstart.md) assumes you already have a **Voyager installation that contains this
+instrument**. This page is how you get one.
+
+You do **not** need the official `voyager-full.zip` bundle, and you do not need to wait for DepMiner
+to be included in it. You can build your own Voyager install containing exactly the instruments you
+want — that is the normal way to try a new instrument version.
+
+!!! info "Download size"
+    `depminer-voyager.zip` is large (**several hundred MB**) because it bundles the Syft and Trivy
+    binaries for five OS/architecture targets. That is what buys the 100%-offline guarantee: the
+    scan itself never downloads anything. See [Bundled Tools](tools.md).
+
+## Option A — build your own bundle with voyenv (recommended)
+
+`voyenv` is the tool that assembles a Voyager installation from a list of instruments. It needs
+**Node.js**.
+
+**1. Install voyenv**
+
+```bash
+npm i -g @dxworks/voyenv
+```
+
+**2. Write a `voyenv.yml`** in an empty folder:
+
+```yaml
+name: voyager
+voyager_version: v1.6.2
+
+instruments:
+  - name: dxworks/depminer
+    tag: v0.4.0-voyager
+    asset: depminer-voyager.zip
+
+tokens:
+runtimes:
+```
+
+**3. Build the install**
+
+```bash
+voyenv install
+```
+
+This downloads Voyager itself plus each instrument listed, unpacks them, and writes a ready-to-use
+`voyager/` folder containing `voyager.sh` / `voyager.bat`, `dx-voyager.jar`, and
+`instruments/depminer/`. It also writes a `.config.yml` with `runsAll: false`, which is what lets a
+mission select individual commands.
+
+`cd voyager/` and continue with [Quick Start](quickstart.md).
+
+!!! tip "Mixing in other instruments"
+    Add more entries under `instruments:` to build a bundle with several tools — the format is the
+    same for every dxworks instrument:
+
+    ```yaml
+      - name: dxworks/inspector-git
+        tag: v1.7.0-voyager
+        asset: iglog-voyager.zip
+    ```
+
+!!! note "Pinning versions"
+    The `tag:` line pins the exact instrument release, and must match a tag that actually exists —
+    check the [releases page](https://github.com/dxworks/depminer/releases) and use the newest
+    `v*-voyager` entry. Omit the line to always take the latest. Pinning is recommended when you
+    want a reproducible install — a rebuild then always produces the same bundle.
+
+## Option B — add it to an existing Voyager install
+
+If you already have a Voyager installation, you can drop the instrument in beside the others:
+
+1. Download `depminer-voyager.zip` from the
+   [releases page](https://github.com/dxworks/depminer/releases) (pick a `v*-voyager` release).
+2. Unzip it into the install's `instruments/` folder, so you end up with `instruments/depminer/`
+   containing `instrument.yml`, `depminer.jar`, and `bin/`.
+3. Confirm the install's `.config.yml` has `runsAll: false` — without it, mission command selection
+   is ignored and Voyager runs everything it finds.
+
+!!! note "Executable permissions are handled for you"
+    Some unzip implementations drop the executable bit on the bundled Syft/Trivy binaries. The
+    wrappers restore it themselves at run time, so this normally needs no action. If you do hit a
+    permission error, `chmod +x instruments/depminer/bin/*` clears it.
+
+## Verifying the install
+
+From inside the `voyager/` folder:
+
+```bash
+java -version                      # JDK 11+ must be present — see Quick Start prerequisites
+ls instruments/depminer            # expect: instrument.yml, depminer.jar, bin/, README.md
+```
+
+Then run a mission as described in [Quick Start](quickstart.md). A successful run prints a summary
+with one line per command and writes `<mission>-voyager-results.zip`.

--- a/docs/prep-guide.md
+++ b/docs/prep-guide.md
@@ -1,0 +1,144 @@
+# Preparing Your Project for a Complete Scan
+
+This instrument scans **whatever technologies it finds** in your repositories — Java, Node,
+Python, Go, Rust, .NET, PHP, Ruby, and more — automatically, in a single pass. You do **not**
+tell it what stack you use; it detects everything present.
+
+The one thing it needs from you is that your project is in a **resolved** state on disk before we
+scan. Here is why, and the minimal steps to get there.
+
+## Why any prep is needed at all
+
+Syft and Trivy are **static readers**. They do **not** build your project, run your package
+manager, or reach the internet (this instrument is 100% offline). They report exactly the
+dependencies that are already written down on disk:
+
+- A **lock file** (`package-lock.json`, `Cargo.lock`, `poetry.lock`, `gradle.lockfile`, …) lists
+  the **full transitive tree** — every direct *and* indirect dependency, pinned. When one is
+  present, the scan is complete with zero effort.
+- A bare **manifest** (`pom.xml`, `build.gradle`, a hand-written `requirements.txt`) lists only
+  the **direct** dependencies. Without a resolved lock file or a warm local cache, the scan sees
+  the direct deps only — the transitive tree is missing.
+
+So "prep" means one thing: **make the resolved state exist before we scan.** For most projects it
+already does.
+
+## The 30-second version
+
+| Your stack | What to do |
+|---|---|
+| npm / yarn / pnpm, Go, Rust, Ruby, PHP, .NET, Python (Poetry / Pipenv / uv) | **Nothing** — just make sure the lock file is committed (it usually is). |
+| **Maven** | Run one command to warm the local cache — see [Maven](#maven). |
+| **Gradle** | Generate lock files once — see [Gradle](#gradle). |
+| Python with a bare `requirements.txt` | Regenerate it fully-pinned — see [Python](#python-bare-requirementstxt). |
+
+If your project is only in the first row, you are done. The rest of this page is for the three
+cases that need a one-time command.
+
+!!! warning "Prep on a machine that can build the project"
+    Do the prep where your build tools live, and — for the one-time resolve step — with internet.
+    The *scan itself* is always offline; prep and scan are separate steps. See
+    [Where prep must happen](#where-the-prep-must-happen) for the one important detail about Maven.
+
+## Maven
+
+A `pom.xml` does **not** store the resolved dependency tree — Maven normally rebuilds it by
+reaching Maven Central. Offline, we instead read your **local Maven cache** at `~/.m2/repository`.
+So the prep is to fill that cache once:
+
+```bash
+# In the project directory, on a machine with internet + Maven installed:
+mvn dependency:go-offline
+# (a normal build works too and is more thorough:)
+# mvn install -DskipTests
+```
+
+That downloads every dependency's metadata into `~/.m2/repository`. After that, both scanners
+resolve the **full transitive tree** from the cache — no network.
+
+!!! example "Measured effect (Apache Zeppelin, offline)"
+    Maven components detected went from **~1000 → ~2400 (Trivy)** and **~300 → ~4000 (Syft)** once
+    `~/.m2` was warmed. Same repo, same scan — the only difference is the cache.
+
+If your build machine already compiles this project regularly, `~/.m2` is **already warm** and you
+need to do nothing.
+
+## Gradle
+
+Gradle has no lock file by default. Generate one so the resolved tree lands in a file that travels
+inside the repo:
+
+```bash
+# One-time: enable dependency locking in build.gradle (or settings.gradle):
+#   dependencyLocking { lockAllConfigurations() }
+# Then, on a machine with internet:
+./gradlew dependencies --write-locks
+```
+
+This writes `gradle.lockfile` (per module). Commit it. Both scanners read it and report the full
+tree — and because it lives in the repo, it is portable (no cache needed at scan time).
+
+## Python (bare `requirements.txt`)
+
+A hand-written `requirements.txt` usually lists only direct dependencies. Regenerate a fully
+resolved one:
+
+```bash
+# Option A — pip-tools (does not install anything):
+pip-compile            # turns requirements.in / pyproject into a pinned requirements.txt
+
+# Option B — from a virtualenv where the app is already installed:
+pip freeze > requirements.txt
+```
+
+If you use **Poetry, Pipenv, or uv**, no prep is needed — commit `poetry.lock` / `Pipfile.lock` /
+`uv.lock` and you already have the full tree.
+
+## Everything else (npm, Go, Rust, .NET, PHP, Ruby …)
+
+No prep beyond having the lock file committed, which is normal practice:
+
+| Stack | Lock file that must be present |
+|---|---|
+| npm / yarn / pnpm | `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` |
+| Go (1.17+) | `go.mod` (+ `go.sum`) |
+| Rust | `Cargo.lock` |
+| .NET | `packages.lock.json` (enable NuGet lock files if absent) |
+| PHP | `composer.lock` |
+| Ruby | `Gemfile.lock` |
+
+If one is missing, run the ecosystem's install once (`npm ci`, `dotnet restore`, …) to create it,
+and commit it.
+
+## Where the prep must happen
+
+There are two shapes of prep, and they differ in one important way:
+
+| Prep produces… | Lives in… | Portable? |
+|---|---|---|
+| A **lock file** (Gradle, npm, Python-lock, etc.) | a file **inside the repo** | :material-check: Yes — prep anywhere, the file ships with the code |
+| A **warm cache** (Maven `~/.m2`) | the user's **home directory**, not the repo | :material-alert: No — see below |
+
+**Maven is the one to watch.** Its resolved data sits in `~/.m2` on whichever machine did the
+build, *not* in the repo. The scanners read the `~/.m2` of the machine **running the scan**. So for
+Maven, do one of:
+
+1. **Run `mvn dependency:go-offline` and the scan on the same machine (same user home).** Simplest,
+   and automatic if the client scans on its own build box.
+2. Otherwise, carry the warmed `~/.m2` to the scan machine (or point the tools at a project-local
+   cache — Syft honors `SYFT_JAVA_MAVEN_LOCAL_REPOSITORY_DIR`).
+
+Lock-file ecosystems have no such constraint — the lock file travels with the repo.
+
+## How to check it worked
+
+After prep, a quick sanity check: the number of Maven/other components in a scan should be much
+higher than "just the direct dependencies you wrote in the manifest." If a Maven project reports
+only a few dozen components, `~/.m2` was probably not warm on the scan machine.
+
+## What this cannot do
+
+The scanners find any technology **they support** (broad — essentially every mainstream
+ecosystem). A stack neither tool catalogs — e.g. Bazel, Scala SBT, Perl/CPAN — will not appear no
+matter how you prep, because there is no lock file or cache these tools know how to read for it.
+For the full supported-ecosystem list, see the tools' own documentation.

--- a/docs/prep-guide.md
+++ b/docs/prep-guide.md
@@ -48,13 +48,28 @@ So the prep is to fill that cache once:
 
 ```bash
 # In the project directory, on a machine with internet + Maven installed:
-mvn dependency:go-offline
+mvn dependency:go-offline -fae
 # (a normal build works too and is more thorough:)
 # mvn install -DskipTests
 ```
 
 That downloads every dependency's metadata into `~/.m2/repository`. After that, both scanners
 resolve the **full transitive tree** from the cache — no network.
+
+!!! tip "Use `-fae` (fail at end) — a partial warm cache is still a big win"
+    In a large multi-module project, it is normal for a module or two to fail to resolve, and by
+    default Maven **stops at the first failure**, leaving the rest of the cache cold. `-fae`
+    (`--fail-at-end`) keeps going and warms everything it can. `-fn` (`--fail-never`) is even more
+    permissive.
+
+    The common cause is a **JDK mismatch**: older projects declare JDK-8-era artifacts such as
+    `jdk.tools:jdk.tools` or `com.sun:tools` (the old `tools.jar`), which do not exist on modern
+    JDKs and fail to resolve no matter what. Those modules simply will not be cached — every other
+    module still is, and the scan still improves enormously. If you need those modules too, run the
+    prep with the older JDK the project was written for.
+
+    Scanning is unaffected either way: prep failures never break the scan, they only limit how much
+    of the transitive tree it can see.
 
 !!! example "Measured effect (Apache Zeppelin, offline)"
     Maven components detected went from **~1000 → ~2400 (Trivy)** and **~300 → ~4000 (Syft)** once

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,57 @@
+# Quick Start
+
+DepMiner runs as a **Voyager instrument**. You give Voyager a mission that points at a folder of
+repositories; DepMiner mines the dependencies and writes SBOMs.
+
+## 1. Point a mission at your repositories
+
+Create a `mission.yml`:
+
+```yaml
+mission: my-analysis
+target: /path/to/repos
+instruments:
+  depminer:
+    commands:
+      - Mine Dependencies
+      - Syft SBOM
+      - Trivy Extract
+```
+
+!!! note "Command names are exact"
+    The `commands` values must match the [command names](index.md) exactly:
+    `Mine Dependencies`, `Syft SBOM`, `Trivy Extract`. If `commands` is empty or missing, Voyager
+    runs **all three** (this requires `runsAll: false` in the install's `.config.yml`, which
+    voyenv-built bundles already set).
+
+## 2. Run the mission
+
+```bash
+./voyager.sh mission.yml
+```
+
+## 3. Find your results
+
+Everything lands under `depminer/results/`:
+
+| File | Produced by |
+|---|---|
+| `pom-*.xml`, `package-*.json`, … + `index.json` | depminer |
+| `<project>.syft.json`, `<project>.cdx.json`, `<project>.spdx.json` | Syft |
+| `<project>.trivy.cdx.json` | Trivy |
+
+## Getting complete (transitive) results
+
+Syft and Trivy read your project's **already-resolved** dependency state — a lock file or a warm
+local cache — they do **not** build your project. For most ecosystems the lock file is already
+committed and you need to do **nothing**.
+
+A few stacks (Maven, Gradle, and a bare `requirements.txt`) need one minimal, one-time prep step
+so the scan captures the full transitive tree instead of only the directly-declared dependencies.
+
+👉 See **[Preparing Your Project](prep-guide.md)** for the per-technology steps.
+
+## Choosing which tools run
+
+You do not have to run all three every time. See **[Configuration](configuration.md)** for two ways
+to select tools: listing commands per mission, or flipping per-tool environment switches.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,6 +17,8 @@ repositories; DepMiner mines the dependencies and writes SBOMs.
 - **A Voyager installation containing this instrument** — the folder holding `voyager.sh`
   (`voyager.bat` on Windows), `dx-voyager.jar`, and `instruments/depminer/`. **Run every command on
   this page from inside that folder**, and put your `mission.yml` there too.
+  Don't have one yet? See **[Installing](install.md)** — you can build one in two commands with
+  `voyenv`, without waiting for the official Voyager bundle.
 
 Syft and Trivy need **nothing** installed — their binaries ship inside the bundle.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,6 +3,23 @@
 DepMiner runs as a **Voyager instrument**. You give Voyager a mission that points at a folder of
 repositories; DepMiner mines the dependencies and writes SBOMs.
 
+## Prerequisites
+
+- **A Java runtime — JDK 11 or newer.** Voyager is a Java application: `voyager.sh` is a one-line
+  wrapper around `java -jar dx-voyager.jar`. Verify with `java -version` **before** you start.
+
+    !!! warning "If `java` is missing, the error will not mention Voyager"
+        With no JDK on your `PATH`, step 2 below fails with a bare operating-system message such as
+        `Unable to locate a Java Runtime` (macOS) or `java: command not found`. Nothing in it points
+        at Voyager or DepMiner. Install a JDK (Temurin, or `brew install openjdk` on macOS) and make
+        sure it is on your `PATH`.
+
+- **A Voyager installation containing this instrument** — the folder holding `voyager.sh`
+  (`voyager.bat` on Windows), `dx-voyager.jar`, and `instruments/depminer/`. **Run every command on
+  this page from inside that folder**, and put your `mission.yml` there too.
+
+Syft and Trivy need **nothing** installed — their binaries ship inside the bundle.
+
 ## 1. Point a mission at your repositories
 
 Create a `mission.yml`:
@@ -32,13 +49,34 @@ instruments:
 
 ## 3. Find your results
 
-Everything lands under `depminer/results/`:
+**Your results are delivered as a zip file in the Voyager folder**, named after the `mission:` value
+inside your mission file:
+
+```
+<mission>-voyager-results.zip
+```
+
+So the example above (`mission: my-analysis`) produces **`my-analysis-voyager-results.zip`**, next to
+`voyager.sh`. Note the name comes from the `mission:` field, **not** from the mission file's
+filename — a file called `my-mission.yml` declaring `mission: my-analysis` still yields
+`my-analysis-voyager-results.zip`.
+
+!!! warning "Don't go looking for a leftover results folder"
+    While the mission runs, the instrument writes into `instruments/depminer/results/`. Voyager
+    **zips that folder and then deletes it** as the run finishes, so afterwards it is empty. That is
+    normal — the zip is the deliverable. The last lines of the run log confirm it:
+    `Results written to <mission>-voyager-results.zip`.
+
+Unzip it and you get a `depminer/results/` directory containing:
 
 | File | Produced by |
 |---|---|
 | `pom-*.xml`, `package-*.json`, … + `index.json` | depminer |
 | `<project>.syft.json`, `<project>.cdx.json`, `<project>.spdx.json` | Syft |
 | `<project>.trivy.cdx.json` | Trivy |
+
+The zip also contains `mission-report.log` (the per-command SUCCESS/FAILED summary), `depminer.log`,
+and a copy of the mission file you ran.
 
 ## Getting complete (transitive) results
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,51 @@
+# Bundled Tools
+
+DepMiner ships Syft and Trivy **inside the release bundle** so a mission run never downloads
+anything. This page documents the pinned versions and the offline guarantees.
+
+## Versions
+
+| Tool | Version | Source |
+|---|---|---|
+| Syft | 1.46.0 | [github.com/anchore/syft](https://github.com/anchore/syft) (pinned in `scripts/prepare-release-voyager.sh`) |
+| Trivy | 0.72.0 | [github.com/aquasecurity/trivy](https://github.com/aquasecurity/trivy) (pinned in `scripts/prepare-release-voyager.sh`) |
+
+The wrappers in `bin/` pick the binary matching the host OS/arch and fall back to a tool on `PATH`
+only when no bundled binary exists (a development convenience — release bundles always contain the
+binaries).
+
+## Platforms
+
+Binaries are bundled for:
+
+- **Linux** — amd64 + arm64
+- **macOS** — amd64 + arm64
+- **Windows** — amd64
+
+## Offline guarantees
+
+Syft and Trivy run **extraction-only and 100% offline**. Specifically, they do **not**:
+
+- consult vulnerability databases,
+- send telemetry,
+- perform version / update checks,
+- reach registries or Maven Central.
+
+They only **read the target folder and write SBOM files**. The single exception to "no network"
+is the *optional, one-time* prep step some ecosystems need — and that is run by you, separately,
+before the scan (see [Preparing Your Project](prep-guide.md)). The scan itself never touches the
+network.
+
+## Output formats
+
+| Tool | Formats written per project |
+|---|---|
+| Syft | native Syft JSON (`.syft.json`), CycloneDX (`.cdx.json`), SPDX (`.spdx.json`) |
+| Trivy | CycloneDX (`.trivy.cdx.json`) |
+
+## Supported ecosystems
+
+Between them the two scanners catalog essentially every mainstream ecosystem — Java, Node, Python,
+Go, Rust, .NET, PHP, Ruby, and more. A stack neither tool catalogs (e.g. Bazel, Scala SBT,
+Perl/CPAN) will not appear. For the authoritative supported-ecosystem lists, see each tool's own
+documentation.

--- a/instrument.yml
+++ b/instrument.yml
@@ -9,6 +9,26 @@ commands:
     win: java -jar depminer.jar extract "${repo}" "${instrument}/results"
     unix: java -jar depminer.jar extract "${repo}" "${instrument}/results"
 
+  # Syft and Trivy run EXTRACTION-ONLY and 100% OFFLINE: SBOM inventories only,
+  # no vulnerability DBs, no network calls of any kind.
+  # run is "once", so ${repo} is the target folder holding all repositories;
+  # the wrappers loop over each project inside it and write per-project SBOMs.
+  - name: Syft SBOM
+    win: powershell -ExecutionPolicy Bypass -File "${instrument}/bin/syft-wrapper.ps1" "${repo}" "${instrument}/results"
+    unix: bash "${instrument}/bin/syft-wrapper.sh" "${repo}" "${instrument}/results"
+
+  - name: Trivy Extract
+    win: powershell -ExecutionPolicy Bypass -File "${instrument}/bin/trivy-wrapper.ps1" "${repo}" "${instrument}/results"
+    unix: bash "${instrument}/bin/trivy-wrapper.sh" "${repo}" "${instrument}/results"
+
 environment:
+  # Close every Syft network touchpoint. Env vars beat any stray .syft.yaml on the host.
+  # The app-update check is the only one that is ON by default; the rest are pins.
+  SYFT_CHECK_FOR_APP_UPDATE: "false"
+  SYFT_GOLANG_SEARCH_REMOTE_LICENSES: "false"
+  SYFT_GOLANG_USE_PACKAGES_LIB: "false"
+  SYFT_JAVA_USE_NETWORK: "false"
+  SYFT_JAVASCRIPT_SEARCH_REMOTE_LICENSES: "false"
+  SYFT_PYTHON_SEARCH_REMOTE_LICENSES: "false"
 #  DEPMINER_DEPMINER_FILE: "depminer.yml"
 #  DEPMINER_IGNORE_FILE: ".ignore.yml"

--- a/instrument.yml
+++ b/instrument.yml
@@ -37,13 +37,15 @@ environment:
   SYFT_GOLANG_SEARCH_REMOTE_LICENSES: "false"
   SYFT_GOLANG_USE_PACKAGES_LIB: "false"
   SYFT_JAVA_USE_NETWORK: "false"
-  # Maven transitive deps, still 100% offline: resolve the full tree from the host's local
-  # Maven cache (~/.m2/repository) instead of the network. BOTH are required together, and
-  # neither alone changes anything. They only help when the client pre-populated ~/.m2 (see
-  # PREP_GUIDE.md); with an empty cache they are harmless no-ops. USE_NETWORK stays "false",
-  # so no network call is ever made. Without these, Syft reports only DECLARED Maven deps.
-  SYFT_JAVA_RESOLVE_TRANSITIVE_DEPENDENCIES: "true"
-  SYFT_JAVA_USE_MAVEN_LOCAL_REPOSITORY: "true"
+  # Maven transitive deps, still 100% offline: the wrappers default
+  # SYFT_JAVA_RESOLVE_TRANSITIVE_DEPENDENCIES and SYFT_JAVA_USE_MAVEN_LOCAL_REPOSITORY to
+  # "true" — resolve the full tree from the host's local Maven cache (~/.m2/repository)
+  # instead of the network. BOTH are required together; they only help when the client
+  # pre-populated ~/.m2 (see PREP_GUIDE.md), and with an empty cache they are harmless
+  # no-ops. Without them, Syft reports only DECLARED Maven deps.
+  # Like DEPMINER_RUN_* above, they are deliberately NOT pinned here so clients can set
+  # them to "false" in mission.yml / .config.yml / the host shell. USE_NETWORK stays
+  # "false" regardless, so no network call is ever made either way.
   SYFT_JAVASCRIPT_SEARCH_REMOTE_LICENSES: "false"
   SYFT_PYTHON_SEARCH_REMOTE_LICENSES: "false"
 #  DEPMINER_DEPMINER_FILE: "depminer.yml"

--- a/instrument.yml
+++ b/instrument.yml
@@ -4,10 +4,19 @@ run: once
 results:
   - dir: ${instrument}/results
 
+# Per-tool switches (all tools are ON by default):
+#   DEPMINER_RUN_MINER=false  → skip depminer's own extraction
+#   DEPMINER_RUN_SYFT=false   → skip Syft
+#   DEPMINER_RUN_TRIVY=false  → skip Trivy
+# Set them in the mission.yml "environment:" block (wins over everything), in the
+# voyager install's .config.yml, or in the shell that launches voyager.
+# Deliberately NOT defaulted in the environment block below: instrument env overrides
+# the host shell env in Voyager, so pinning "true" here would break ad-hoc
+# `DEPMINER_RUN_X=false ./voyager.sh` usage. Defaults live in the commands/wrappers.
 commands:
   - name: Mine Dependencies
-    win: java -jar depminer.jar extract "${repo}" "${instrument}/results"
-    unix: java -jar depminer.jar extract "${repo}" "${instrument}/results"
+    win: if /I "%DEPMINER_RUN_MINER%"=="false" (echo depminer disabled - skipping) else (java -jar depminer.jar extract "${repo}" "${instrument}/results")
+    unix: if [ "${DEPMINER_RUN_MINER:-true}" = "false" ]; then echo "depminer disabled - skipping"; else java -jar depminer.jar extract "${repo}" "${instrument}/results"; fi
 
   # Syft and Trivy run EXTRACTION-ONLY and 100% OFFLINE: SBOM inventories only,
   # no vulnerability DBs, no network calls of any kind.

--- a/instrument.yml
+++ b/instrument.yml
@@ -37,6 +37,13 @@ environment:
   SYFT_GOLANG_SEARCH_REMOTE_LICENSES: "false"
   SYFT_GOLANG_USE_PACKAGES_LIB: "false"
   SYFT_JAVA_USE_NETWORK: "false"
+  # Maven transitive deps, still 100% offline: resolve the full tree from the host's local
+  # Maven cache (~/.m2/repository) instead of the network. BOTH are required together, and
+  # neither alone changes anything. They only help when the client pre-populated ~/.m2 (see
+  # PREP_GUIDE.md); with an empty cache they are harmless no-ops. USE_NETWORK stays "false",
+  # so no network call is ever made. Without these, Syft reports only DECLARED Maven deps.
+  SYFT_JAVA_RESOLVE_TRANSITIVE_DEPENDENCIES: "true"
+  SYFT_JAVA_USE_MAVEN_LOCAL_REPOSITORY: "true"
   SYFT_JAVASCRIPT_SEARCH_REMOTE_LICENSES: "false"
   SYFT_PYTHON_SEARCH_REMOTE_LICENSES: "false"
 #  DEPMINER_DEPMINER_FILE: "depminer.yml"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,11 @@ site_description: >-
   DepMiner (DepMi) — a Voyager instrument that mines dependency information and
   produces offline SBOMs with depminer, Syft, and Trivy.
 
+# The published location (GitHub Pages via the org's dxworks.org domain). Required for a
+# populated sitemap.xml, canonical links, and Material's navigation.instant — all of which
+# are silently skipped when it is unset.
+site_url: https://dxworks.org/depminer/
+
 repo_url: https://github.com/dxworks/depminer
 repo_name: dxworks/depminer
 edit_uri: edit/main/docs/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,67 @@
+site_name: DepMiner
+site_description: >-
+  DepMiner (DepMi) — a Voyager instrument that mines dependency information and
+  produces offline SBOMs with depminer, Syft, and Trivy.
+
+repo_url: https://github.com/dxworks/depminer
+repo_name: dxworks/depminer
+edit_uri: edit/main/docs/
+
+copyright: Copyright &copy; DxWorks
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.top
+    - navigation.indexes
+    - content.action.edit
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+  palette:
+    # Light mode
+    - scheme: default
+      media: "(prefers-color-scheme: light)"
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+    # Dark mode
+    - scheme: slate
+      media: "(prefers-color-scheme: dark)"
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
+
+plugins:
+  - search
+
+markdown_extensions:
+  - toc:
+      permalink: true
+  - tables
+  - attr_list
+  - md_in_html
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+extra:
+  generator: false
+
+nav:
+  - Home: index.md
+  - Quick Start: quickstart.md
+  - Preparing Your Project: prep-guide.md
+  - Configuration: configuration.md
+  - Bundled Tools: tools.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ extra:
 
 nav:
   - Home: index.md
+  - Installing: install.md
   - Quick Start: quickstart.md
   - Preparing Your Project: prep-guide.md
   - Configuration: configuration.md

--- a/releaseNotes/v0.4.0.md
+++ b/releaseNotes/v0.4.0.md
@@ -1,0 +1,11 @@
+The Voyager instrument now runs **three tools per mission** — depminer, Syft, and Trivy — instead of one.
+
+* **New commands `Syft SBOM` and `Trivy Extract`** alongside the existing `Mine Dependencies`. Syft writes native Syft JSON, CycloneDX and SPDX per project; Trivy writes CycloneDX.
+* **Extraction-only and 100% offline.** No vulnerability databases, telemetry, version checks, or registry/Maven Central lookups. Syft and Trivy binaries are bundled for linux/macOS (amd64+arm64) and windows (amd64), so a mission run downloads nothing.
+* **Per-tool switches** `DEPMINER_RUN_MINER`, `DEPMINER_RUN_SYFT`, `DEPMINER_RUN_TRIVY` — all on by default, set one to `"false"` in `mission.yml` to skip it. Individual commands can also be selected per mission.
+* **Full transitive Maven trees offline.** Syft resolves from the local `~/.m2` cache via `SYFT_JAVA_RESOLVE_TRANSITIVE_DEPENDENCIES` and `SYFT_JAVA_USE_MAVEN_LOCAL_REPOSITORY` (both overridable, network stays off). On Apache Zeppelin this took Syft's Maven components from ~300 to ~4000 and Trivy's from ~1000 to ~2400, with a warm cache and no network.
+* **One failing project no longer aborts the scan.** The failure is logged, remaining projects still get their SBOMs, and the command reports a summary of what failed.
+* **Hardened release build.** Every downloaded Syft/Trivy asset is verified against a pinned sha256 before it is bundled.
+* **New documentation site** at <https://dxworks.org/depminer/>, covering installation, per-technology preparation, configuration, and the offline guarantees.
+
+Pinned tool versions: Syft 1.46.0, Trivy 0.72.0.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+# Pinned so `mkdocs build` is byte-reproducible across CI runs and machines.
+# Bump deliberately, not automatically.
+mkdocs-material==9.6.9

--- a/scripts/prepare-release-voyager.sh
+++ b/scripts/prepare-release-voyager.sh
@@ -7,6 +7,54 @@ VERSION="${1:?Usage: prepare-release-voyager.sh <version>}"
 SYFT_VERSION="1.46.0"
 TRIVY_VERSION="0.72.0"
 
+# Official sha256 checksums for the pinned versions, taken from each project's release
+# checksums file (syft_<v>_checksums.txt / trivy_<v>_checksums.txt on the GitHub release).
+# Bump these together with the versions above — a version bump without new checksums
+# fails fast with "no pinned checksum".
+CHECKSUMS="
+d654f678b709eb53c393d38519d5ed7d2e57205529404018614cfefa0fb2b5ca  syft_1.46.0_linux_amd64.tar.gz
+9fafef4db4f032ce81008d3a1529985d41ceb6ccdf2b388c9ce2f1ed7d32082e  syft_1.46.0_linux_arm64.tar.gz
+5c983db13533de02e5331aae88091116f25365840741f86234084a30166672a7  syft_1.46.0_darwin_amd64.tar.gz
+cd4e2c40e075684a5746d8959f76b6572bb2d2dda8cf6877dbfff1cc0baeea01  syft_1.46.0_darwin_arm64.tar.gz
+1e515c1ac4bc65917f8d0a52b6ae0e611082779cbf2da9d470282158dd24ea13  syft_1.46.0_windows_amd64.zip
+bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea  trivy_0.72.0_Linux-64bit.tar.gz
+2ca2c023109c2db6b2b77366b6717291452d4531167377d95c79547f0c8e3467  trivy_0.72.0_Linux-ARM64.tar.gz
+ee5e60df8a98e5b89fd74a6d86f9e5c7e9a266a35002cb1e43291698b3bfee08  trivy_0.72.0_macOS-64bit.tar.gz
+88f208680dc05da2b459e19b4f5aa2b4dc7c2117892ba4aab2ae63baba330016  trivy_0.72.0_macOS-ARM64.tar.gz
+ed3cf122060f61818fe1f735fd97557954e16e10bc8b058af9852271cf2e91b3  trivy_0.72.0_windows-64bit.zip
+"
+
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+# Download <base>/<asset> to <dest> and verify it against the pinned checksum above.
+fetch_verified() {
+  local base="$1" asset="$2" dest="$3" expected actual
+  echo "fetching ${asset}"
+  curl -fsSL "${base}/${asset}" -o "$dest"
+  expected="$(printf '%s\n' "$CHECKSUMS" | awk -v a="$asset" '$2 == a {print $1}')"
+  if [ -z "$expected" ]; then
+    echo "ERROR: no pinned checksum for ${asset} - update CHECKSUMS when bumping versions" >&2
+    exit 1
+  fi
+  actual="$(sha256 "$dest")"
+  if [ "$actual" != "$expected" ]; then
+    echo "ERROR: checksum mismatch for ${asset}" >&2
+    echo "  expected: ${expected}" >&2
+    echo "  actual:   ${actual}" >&2
+    exit 1
+  fi
+}
+
+# Start from a clean slate: zip -r appends into an existing archive, and stale files
+# in a leftover staging dir would otherwise survive local re-runs.
+rm -rf depminer depminer-voyager.zip
+
 mkdir -p depminer/results depminer/bin
 cp README.md depminer/README.md
 cp PREP_GUIDE.md depminer/PREP_GUIDE.md
@@ -26,14 +74,12 @@ chmod +x depminer/bin/*.sh
 sbase="https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}"
 for t in linux_amd64 linux_arm64 darwin_amd64 darwin_arm64; do
   os="${t%_*}"; arch="${t#*_}"
-  echo "fetching syft_${SYFT_VERSION}_${t}.tar.gz"
-  curl -sSL "${sbase}/syft_${SYFT_VERSION}_${t}.tar.gz" -o /tmp/syft.tgz
+  fetch_verified "$sbase" "syft_${SYFT_VERSION}_${t}.tar.gz" /tmp/syft.tgz
   tar -xzf /tmp/syft.tgz -C /tmp syft
   mv /tmp/syft "depminer/bin/syft-${os}-${arch}"
   chmod +x "depminer/bin/syft-${os}-${arch}"
 done
-echo "fetching syft_${SYFT_VERSION}_windows_amd64.zip"
-curl -sSL "${sbase}/syft_${SYFT_VERSION}_windows_amd64.zip" -o /tmp/syft-win.zip
+fetch_verified "$sbase" "syft_${SYFT_VERSION}_windows_amd64.zip" /tmp/syft-win.zip
 unzip -o -q /tmp/syft-win.zip syft.exe -d /tmp
 mv /tmp/syft.exe depminer/bin/syft-windows-amd64.exe
 
@@ -43,14 +89,12 @@ for spec in "linux amd64 Linux-64bit" "linux arm64 Linux-ARM64" \
             "darwin amd64 macOS-64bit" "darwin arm64 macOS-ARM64"; do
   set -- $spec
   os="$1"; arch="$2"; asset="$3"
-  echo "fetching trivy_${TRIVY_VERSION}_${asset}.tar.gz"
-  curl -sSL "${tbase}/trivy_${TRIVY_VERSION}_${asset}.tar.gz" -o /tmp/trivy.tgz
+  fetch_verified "$tbase" "trivy_${TRIVY_VERSION}_${asset}.tar.gz" /tmp/trivy.tgz
   tar -xzf /tmp/trivy.tgz -C /tmp trivy
   mv /tmp/trivy "depminer/bin/trivy-${os}-${arch}"
   chmod +x "depminer/bin/trivy-${os}-${arch}"
 done
-echo "fetching trivy_${TRIVY_VERSION}_windows-64bit.zip"
-curl -sSL "${tbase}/trivy_${TRIVY_VERSION}_windows-64bit.zip" -o /tmp/trivy-win.zip
+fetch_verified "$tbase" "trivy_${TRIVY_VERSION}_windows-64bit.zip" /tmp/trivy-win.zip
 unzip -o -q /tmp/trivy-win.zip trivy.exe -d /tmp
 mv /tmp/trivy.exe depminer/bin/trivy-windows-amd64.exe
 

--- a/scripts/prepare-release-voyager.sh
+++ b/scripts/prepare-release-voyager.sh
@@ -3,12 +3,54 @@ set -euo pipefail
 
 VERSION="${1:?Usage: prepare-release-voyager.sh <version>}"
 
-mkdir -p depminer/results
+# Pinned tool versions bundled into the Voyager instrument.
+SYFT_VERSION="1.46.0"
+TRIVY_VERSION="0.72.0"
+
+mkdir -p depminer/results depminer/bin
 cp README.md depminer/README.md
 cp target/depminer.jar depminer/depminer.jar
 cp instrument.yml depminer/instrument.yml
 cp depminer.yml depminer/depminer.yml
 cp sanitize.yml depminer/sanitize.yml
 cp .ignore.yml depminer/.ignore.yml
+
+cp bin/syft-wrapper.sh depminer/bin/syft-wrapper.sh
+cp bin/syft-wrapper.ps1 depminer/bin/syft-wrapper.ps1
+cp bin/trivy-wrapper.sh depminer/bin/trivy-wrapper.sh
+cp bin/trivy-wrapper.ps1 depminer/bin/trivy-wrapper.ps1
+chmod +x depminer/bin/*.sh
+
+# --- Syft binaries (single self-contained executable per platform) ---
+sbase="https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}"
+for t in linux_amd64 linux_arm64 darwin_amd64 darwin_arm64; do
+  os="${t%_*}"; arch="${t#*_}"
+  echo "fetching syft_${SYFT_VERSION}_${t}.tar.gz"
+  curl -sSL "${sbase}/syft_${SYFT_VERSION}_${t}.tar.gz" -o /tmp/syft.tgz
+  tar -xzf /tmp/syft.tgz -C /tmp syft
+  mv /tmp/syft "depminer/bin/syft-${os}-${arch}"
+  chmod +x "depminer/bin/syft-${os}-${arch}"
+done
+echo "fetching syft_${SYFT_VERSION}_windows_amd64.zip"
+curl -sSL "${sbase}/syft_${SYFT_VERSION}_windows_amd64.zip" -o /tmp/syft-win.zip
+unzip -o -q /tmp/syft-win.zip syft.exe -d /tmp
+mv /tmp/syft.exe depminer/bin/syft-windows-amd64.exe
+
+# --- Trivy binaries (single self-contained executable per platform) ---
+tbase="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}"
+for spec in "linux amd64 Linux-64bit" "linux arm64 Linux-ARM64" \
+            "darwin amd64 macOS-64bit" "darwin arm64 macOS-ARM64"; do
+  set -- $spec
+  os="$1"; arch="$2"; asset="$3"
+  echo "fetching trivy_${TRIVY_VERSION}_${asset}.tar.gz"
+  curl -sSL "${tbase}/trivy_${TRIVY_VERSION}_${asset}.tar.gz" -o /tmp/trivy.tgz
+  tar -xzf /tmp/trivy.tgz -C /tmp trivy
+  mv /tmp/trivy "depminer/bin/trivy-${os}-${arch}"
+  chmod +x "depminer/bin/trivy-${os}-${arch}"
+done
+echo "fetching trivy_${TRIVY_VERSION}_windows-64bit.zip"
+curl -sSL "${tbase}/trivy_${TRIVY_VERSION}_windows-64bit.zip" -o /tmp/trivy-win.zip
+unzip -o -q /tmp/trivy-win.zip trivy.exe -d /tmp
+mv /tmp/trivy.exe depminer/bin/trivy-windows-amd64.exe
 
 zip -r depminer-voyager.zip depminer

--- a/scripts/prepare-release-voyager.sh
+++ b/scripts/prepare-release-voyager.sh
@@ -9,6 +9,7 @@ TRIVY_VERSION="0.72.0"
 
 mkdir -p depminer/results depminer/bin
 cp README.md depminer/README.md
+cp PREP_GUIDE.md depminer/PREP_GUIDE.md
 cp target/depminer.jar depminer/depminer.jar
 cp instrument.yml depminer/instrument.yml
 cp depminer.yml depminer/depminer.yml


### PR DESCRIPTION
## Summary

The depminer Voyager instrument now runs three tools per mission: **depminer** (unchanged), **Syft**, and **Trivy**. Syft and Trivy generate SBOMs in extraction-only mode and are **100% offline** — no vulnerability DBs, no telemetry, no version checks, no registry/Maven lookups. Production mission runs make zero network calls.

## What changed

- **`bin/syft-wrapper.{sh,ps1}`, `bin/trivy-wrapper.{sh,ps1}`** — cross-platform wrappers that pick the bundled binary for the host OS/arch (restoring exec bits lost to voyenv's unzip), loop over each project in the target (the instrument runs `once`), and fall back to a tool on `PATH` for local development.
- **`instrument.yml`** — registers the two new commands alongside the existing depminer run.
- **`scripts/prepare-release-voyager.sh`** — downloads pinned **syft 1.46.0** and **trivy 0.72.0** binaries at release-build time for linux/macOS (amd64 + arm64) and windows (amd64) and bundles them into the instrument zip. Downloads happen only when building a release, never at mission run time.
- **`README.md`** — documents the three commands, both selection mechanisms, and the offline guarantees; ships inside the Voyager instrument zip.

## Per-tool switches

`DEPMINER_RUN_MINER` / `DEPMINER_RUN_SYFT` / `DEPMINER_RUN_TRIVY` skip the respective command when set to `"false"`; anything else runs it — **all three are ON by default**. Defaults live in the wrappers and command lines rather than in `instrument.yml`'s `environment:` block, so host-shell overrides keep working (instrument env outranks the host shell in Voyager's env merge). Clients flip the switches in their mission.yml `environment:` block.

## Testing

Verified end-to-end in a local Voyager install (`voyager-bundle/voyager/`) with two missions: all tools on (`depminer-mission.yml`) and Trivy disabled via env switch (`depminer-mission-trivy-off.yml`).

## Release note

Merging this does not affect production: shipping requires tagging `v*-voyager` on this repo and updating the depminer entry in dxworks/voyager's `voyenv.yml` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)