### PR TITLE
Strip absolute host paths from the emitted SBOMs

### DIFF
--- a/bin/syft-wrapper.ps1
+++ b/bin/syft-wrapper.ps1
@@ -44,14 +44,79 @@ if (-not (Test-Path $bin)) {
 New-Item -ItemType Directory -Force -Path $Out | Out-Null
 Write-Host ">> syft: $bin"
 
+# --- Host-path scrubbing -------------------------------------------------------
+# The SBOMs are the ONLY artefacts that leave the client's machine, so they must not
+# carry the client's filesystem layout. Both tools record the scanned directory as an
+# ABSOLUTE path in several places (Syft: source.name, source.metadata.path, the "file"
+# component in CycloneDX, the SPDX document name and namespace, plus HOME-derived cache
+# dirs under descriptor.configuration; Trivy: metadata.component.name). No CLI flag
+# covers all of them - Syft's --source-name leaves source.metadata.path and the file
+# component behind, and Trivy has no equivalent flag at all - so the emitted JSON is
+# rewritten here, after the scan.
+#
+# Repo-RELATIVE paths (syft:location:*:path, Trivy's "pom.xml" application component)
+# are deliberately left intact: the downstream parser groups components by them to
+# reconstruct project boundaries.
+#
+# Mirrors the unix wrapper's sanitize_files(). Windows adds one wrinkle: a path can
+# appear in the JSON in three spellings - raw (C:\repos\app), JSON-escaped
+# (C:\\repos\\app) and forward-slashed (C:/repos/app) - so each rule covers all three.
+function Get-AbsPathOrEmpty([string]$p) {
+    if (-not $p) { return "" }
+    try { return (Resolve-Path -LiteralPath $p -ErrorAction Stop).Path } catch { return "" }
+}
+
+function Add-ScrubRule([System.Collections.ArrayList]$rules, [string]$from, [string]$to) {
+    if (-not $from) { return }
+    $from = $from.TrimEnd('\', '/')
+    # Only ABSOLUTE paths are rewritten: a relative one cannot leak a host layout, and
+    # substituting it would corrupt unrelated text.
+    if ($from.Length -lt 2 -or -not [System.IO.Path]::IsPathRooted($from)) { return }
+    foreach ($spelling in @($from, ($from -replace '\\', '\\'), ($from -replace '\\', '/'))) {
+        if ($rules.ToArray() | Where-Object { $_[0] -eq $spelling }) { continue }
+        [void]$rules.Add(@($spelling, $to))
+    }
+}
+
+function Remove-HostPaths([string]$repo, [string]$name, [string[]]$files) {
+    $rules = New-Object System.Collections.ArrayList
+    # Longest / most specific first: the repo sits under the target, which may sit
+    # under HOME. Both the path as passed and its resolved form are covered, because
+    # the tools echo back whichever spelling they were given.
+    Add-ScrubRule $rules $repo $name
+    Add-ScrubRule $rules (Get-AbsPathOrEmpty $repo) $name
+    Add-ScrubRule $rules $Target "."
+    Add-ScrubRule $rules (Get-AbsPathOrEmpty $Target) "."
+    Add-ScrubRule $rules $Out "."
+    Add-ScrubRule $rules (Get-AbsPathOrEmpty $Out) "."
+    Add-ScrubRule $rules $HOME "~"
+    if ($rules.Count -eq 0) { return }
+    foreach ($f in $files) {
+        if (-not (Test-Path -LiteralPath $f)) { continue }
+        $text = [System.IO.File]::ReadAllText($f)
+        foreach ($r in $rules) { $text = $text.Replace($r[0], $r[1]) }
+        [System.IO.File]::WriteAllText($f, $text)
+    }
+}
+# -------------------------------------------------------------------------------
+
 function Scan-One([string]$repo, [string]$name) {
     Write-Host ">> syft scanning: $name"
+    # --source-name pins the root component to the project name instead of the scanned
+    # path; the scrub below covers everything the flag does not reach.
     & $bin scan "dir:$repo" `
+        --source-name $name `
         -o "syft-json=$Out/$name.syft.json" `
         -o "cyclonedx-json=$Out/$name.cdx.json" `
         -o "spdx-json=$Out/$name.spdx.json" `
         -q
-    if ($LASTEXITCODE -ne 0) { throw "syft failed for '$name' (exit $LASTEXITCODE)" }
+    $rc = $LASTEXITCODE
+    # Runs even on failure: a partial SBOM must not leak host paths either.
+    Remove-HostPaths $repo $name @(
+        "$Out/$name.syft.json",
+        "$Out/$name.cdx.json",
+        "$Out/$name.spdx.json")
+    if ($rc -ne 0) { throw "syft failed for '$name' (exit $rc)" }
 }
 
 # One failing project must not cost the others their SBOMs: log it, keep going,

--- a/bin/syft-wrapper.sh
+++ b/bin/syft-wrapper.sh
@@ -62,14 +62,78 @@ fi
 mkdir -p "$OUT"
 echo ">> syft: $BIN"
 
+TARGET_ABS="$(cd "$TARGET" 2>/dev/null && pwd || true)"
+OUT_ABS="$(cd "$OUT" 2>/dev/null && pwd || true)"
+
+# --- Host-path scrubbing -------------------------------------------------------
+# The SBOMs are the ONLY artefacts that leave the client's machine, so they must not
+# carry the client's filesystem layout. Both tools record the scanned directory as an
+# ABSOLUTE path in several places (Syft: source.name, source.metadata.path, the "file"
+# component in CycloneDX, the SPDX document name and namespace, plus HOME-derived cache
+# dirs under descriptor.configuration; Trivy: metadata.component.name). No CLI flag
+# covers all of them - Syft's --source-name leaves source.metadata.path and the file
+# component behind, and Trivy has no equivalent flag at all - so the emitted JSON is
+# rewritten here, after the scan.
+#
+# Repo-RELATIVE paths (syft:location:*:path, Trivy's "pom.xml" application component)
+# are deliberately left intact: the downstream parser groups components by them to
+# reconstruct project boundaries.
+_esc_re()  { printf '%s' "$1" | sed 's/[][\\.*^$\/&]/\\&/g'; }
+_esc_rep() { printf '%s' "$1" | sed 's/[\\\/&]/\\&/g'; }
+_abs()     { (cd "$1" 2>/dev/null && pwd) || true; }
+
+# _rule <absolute-path> <replacement> - appended to $_scrub_script.
+# Only ABSOLUTE paths are rewritten: a relative one cannot leak a host layout, and
+# substituting it would corrupt unrelated text.
+_rule() {
+  local from="${1%/}" to="$2"
+  case "$from" in
+    /?*) _scrub_script="${_scrub_script}s/$(_esc_re "$from")/$(_esc_rep "$to")/g;" ;;
+  esac
+}
+
+# sanitize_files <repo-path-as-passed> <project-name> <file>...
+sanitize_files() {
+  local repo="${1%/}" name="$2"; shift 2
+  local repo_abs f tmp
+  repo_abs="$(_abs "$repo")"
+  _scrub_script=""
+  # Longest / most specific first: the repo sits under the target, which may sit
+  # under HOME. Both the path as passed and its symlink-resolved form are covered,
+  # because the tools echo back whichever spelling they were given.
+  _rule "$repo" "$name"
+  if [ -n "$repo_abs" ] && [ "$repo_abs" != "$repo" ]; then _rule "$repo_abs" "$name"; fi
+  _rule "$TARGET" "."
+  if [ -n "$TARGET_ABS" ] && [ "$TARGET_ABS" != "${TARGET%/}" ]; then _rule "$TARGET_ABS" "."; fi
+  _rule "$OUT" "."
+  if [ -n "$OUT_ABS" ] && [ "$OUT_ABS" != "${OUT%/}" ]; then _rule "$OUT_ABS" "."; fi
+  _rule "${HOME:-}" "~"
+  [ -n "$_scrub_script" ] || return 0
+  for f in "$@"; do
+    [ -f "$f" ] || continue
+    tmp="${f}.scrub"
+    if sed "$_scrub_script" "$f" > "$tmp"; then mv -f "$tmp" "$f"; else rm -f "$tmp"; fi
+  done
+}
+# -------------------------------------------------------------------------------
+
 scan_one() {
-  local repo="$1" name="$2"
+  local repo="$1" name="$2" rc=0
   echo ">> syft scanning: ${name}"
+  # --source-name pins the root component to the project name instead of the scanned
+  # path; the scrub below covers everything the flag does not reach.
   "$BIN" scan "dir:${repo}" \
+    --source-name "${name}" \
     -o "syft-json=${OUT}/${name}.syft.json" \
     -o "cyclonedx-json=${OUT}/${name}.cdx.json" \
     -o "spdx-json=${OUT}/${name}.spdx.json" \
-    -q
+    -q || rc=$?
+  # Runs even on failure: a partial SBOM must not leak host paths either.
+  sanitize_files "$repo" "$name" \
+    "${OUT}/${name}.syft.json" \
+    "${OUT}/${name}.cdx.json" \
+    "${OUT}/${name}.spdx.json"
+  return $rc
 }
 
 # One failing project must not cost the others their SBOMs: log it, keep going,

--- a/bin/trivy-wrapper.ps1
+++ b/bin/trivy-wrapper.ps1
@@ -34,6 +34,62 @@ New-Item -ItemType Directory -Force -Path $Out | Out-Null
 New-Item -ItemType Directory -Force -Path $cache | Out-Null
 Write-Host ">> trivy: $bin"
 
+# --- Host-path scrubbing -------------------------------------------------------
+# The SBOMs are the ONLY artefacts that leave the client's machine, so they must not
+# carry the client's filesystem layout. Both tools record the scanned directory as an
+# ABSOLUTE path in several places (Syft: source.name, source.metadata.path, the "file"
+# component in CycloneDX, the SPDX document name and namespace, plus HOME-derived cache
+# dirs under descriptor.configuration; Trivy: metadata.component.name). No CLI flag
+# covers all of them - Syft's --source-name leaves source.metadata.path and the file
+# component behind, and Trivy has no equivalent flag at all - so the emitted JSON is
+# rewritten here, after the scan.
+#
+# Repo-RELATIVE paths (syft:location:*:path, Trivy's "pom.xml" application component)
+# are deliberately left intact: the downstream parser groups components by them to
+# reconstruct project boundaries.
+#
+# Mirrors the unix wrapper's sanitize_files(). Windows adds one wrinkle: a path can
+# appear in the JSON in three spellings - raw (C:\repos\app), JSON-escaped
+# (C:\\repos\\app) and forward-slashed (C:/repos/app) - so each rule covers all three.
+function Get-AbsPathOrEmpty([string]$p) {
+    if (-not $p) { return "" }
+    try { return (Resolve-Path -LiteralPath $p -ErrorAction Stop).Path } catch { return "" }
+}
+
+function Add-ScrubRule([System.Collections.ArrayList]$rules, [string]$from, [string]$to) {
+    if (-not $from) { return }
+    $from = $from.TrimEnd('\', '/')
+    # Only ABSOLUTE paths are rewritten: a relative one cannot leak a host layout, and
+    # substituting it would corrupt unrelated text.
+    if ($from.Length -lt 2 -or -not [System.IO.Path]::IsPathRooted($from)) { return }
+    foreach ($spelling in @($from, ($from -replace '\\', '\\'), ($from -replace '\\', '/'))) {
+        if ($rules.ToArray() | Where-Object { $_[0] -eq $spelling }) { continue }
+        [void]$rules.Add(@($spelling, $to))
+    }
+}
+
+function Remove-HostPaths([string]$repo, [string]$name, [string[]]$files) {
+    $rules = New-Object System.Collections.ArrayList
+    # Longest / most specific first: the repo sits under the target, which may sit
+    # under HOME. Both the path as passed and its resolved form are covered, because
+    # the tools echo back whichever spelling they were given.
+    Add-ScrubRule $rules $repo $name
+    Add-ScrubRule $rules (Get-AbsPathOrEmpty $repo) $name
+    Add-ScrubRule $rules $Target "."
+    Add-ScrubRule $rules (Get-AbsPathOrEmpty $Target) "."
+    Add-ScrubRule $rules $Out "."
+    Add-ScrubRule $rules (Get-AbsPathOrEmpty $Out) "."
+    Add-ScrubRule $rules $HOME "~"
+    if ($rules.Count -eq 0) { return }
+    foreach ($f in $files) {
+        if (-not (Test-Path -LiteralPath $f)) { continue }
+        $text = [System.IO.File]::ReadAllText($f)
+        foreach ($r in $rules) { $text = $text.Replace($r[0], $r[1]) }
+        [System.IO.File]::WriteAllText($f, $text)
+    }
+}
+# -------------------------------------------------------------------------------
+
 function Scan-One([string]$repo, [string]$name) {
     Write-Host ">> trivy scanning: $name"
     & $bin fs `
@@ -45,7 +101,10 @@ function Scan-One([string]$repo, [string]$name) {
         --output "$Out/$name.trivy.cdx.json" `
         --quiet `
         $repo
-    if ($LASTEXITCODE -ne 0) { throw "trivy failed for '$name' (exit $LASTEXITCODE)" }
+    $rc = $LASTEXITCODE
+    # Runs even on failure: a partial SBOM must not leak host paths either.
+    Remove-HostPaths $repo $name @("$Out/$name.trivy.cdx.json")
+    if ($rc -ne 0) { throw "trivy failed for '$name' (exit $rc)" }
 }
 
 # One failing project must not cost the others their SBOMs: log it, keep going,

--- a/bin/trivy-wrapper.sh
+++ b/bin/trivy-wrapper.sh
@@ -50,8 +50,63 @@ fi
 mkdir -p "$OUT" "$CACHE"
 echo ">> trivy: $BIN"
 
+TARGET_ABS="$(cd "$TARGET" 2>/dev/null && pwd || true)"
+OUT_ABS="$(cd "$OUT" 2>/dev/null && pwd || true)"
+
+# --- Host-path scrubbing -------------------------------------------------------
+# The SBOMs are the ONLY artefacts that leave the client's machine, so they must not
+# carry the client's filesystem layout. Both tools record the scanned directory as an
+# ABSOLUTE path in several places (Syft: source.name, source.metadata.path, the "file"
+# component in CycloneDX, the SPDX document name and namespace, plus HOME-derived cache
+# dirs under descriptor.configuration; Trivy: metadata.component.name). No CLI flag
+# covers all of them - Syft's --source-name leaves source.metadata.path and the file
+# component behind, and Trivy has no equivalent flag at all - so the emitted JSON is
+# rewritten here, after the scan.
+#
+# Repo-RELATIVE paths (syft:location:*:path, Trivy's "pom.xml" application component)
+# are deliberately left intact: the downstream parser groups components by them to
+# reconstruct project boundaries.
+_esc_re()  { printf '%s' "$1" | sed 's/[][\\.*^$\/&]/\\&/g'; }
+_esc_rep() { printf '%s' "$1" | sed 's/[\\\/&]/\\&/g'; }
+_abs()     { (cd "$1" 2>/dev/null && pwd) || true; }
+
+# _rule <absolute-path> <replacement> - appended to $_scrub_script.
+# Only ABSOLUTE paths are rewritten: a relative one cannot leak a host layout, and
+# substituting it would corrupt unrelated text.
+_rule() {
+  local from="${1%/}" to="$2"
+  case "$from" in
+    /?*) _scrub_script="${_scrub_script}s/$(_esc_re "$from")/$(_esc_rep "$to")/g;" ;;
+  esac
+}
+
+# sanitize_files <repo-path-as-passed> <project-name> <file>...
+sanitize_files() {
+  local repo="${1%/}" name="$2"; shift 2
+  local repo_abs f tmp
+  repo_abs="$(_abs "$repo")"
+  _scrub_script=""
+  # Longest / most specific first: the repo sits under the target, which may sit
+  # under HOME. Both the path as passed and its symlink-resolved form are covered,
+  # because the tools echo back whichever spelling they were given.
+  _rule "$repo" "$name"
+  if [ -n "$repo_abs" ] && [ "$repo_abs" != "$repo" ]; then _rule "$repo_abs" "$name"; fi
+  _rule "$TARGET" "."
+  if [ -n "$TARGET_ABS" ] && [ "$TARGET_ABS" != "${TARGET%/}" ]; then _rule "$TARGET_ABS" "."; fi
+  _rule "$OUT" "."
+  if [ -n "$OUT_ABS" ] && [ "$OUT_ABS" != "${OUT%/}" ]; then _rule "$OUT_ABS" "."; fi
+  _rule "${HOME:-}" "~"
+  [ -n "$_scrub_script" ] || return 0
+  for f in "$@"; do
+    [ -f "$f" ] || continue
+    tmp="${f}.scrub"
+    if sed "$_scrub_script" "$f" > "$tmp"; then mv -f "$tmp" "$f"; else rm -f "$tmp"; fi
+  done
+}
+# -------------------------------------------------------------------------------
+
 scan_one() {
-  local repo="$1" name="$2"
+  local repo="$1" name="$2" rc=0
   echo ">> trivy scanning: ${name}"
   "$BIN" fs \
     --cache-dir "$CACHE" \
@@ -61,7 +116,10 @@ scan_one() {
     --format cyclonedx \
     --output "${OUT}/${name}.trivy.cdx.json" \
     --quiet \
-    "$repo"
+    "$repo" || rc=$?
+  # Runs even on failure: a partial SBOM must not leak host paths either.
+  sanitize_files "$repo" "$name" "${OUT}/${name}.trivy.cdx.json"
+  return $rc
 }
 
 # One failing project must not cost the others their SBOMs: log it, keep going,


### PR DESCRIPTION
The SBOMs are the only artefacts that leave the client's air-gapped machine, but both scanners
stamped the client's filesystem layout into them.

## The leak sites, measured on a real Syft 1.46.0 / Trivy 0.72.0 run

| File | Fields carrying an absolute host path |
|---|---|
| `*.syft.json` | `source.name`, `source.metadata.path`, and the HOME-derived `descriptor.configuration` dirs (golang local-mod-cache-dir, java-archive maven-localrepository-dir) |
| `*.cdx.json` (Syft) | `metadata.component.name` and the `file` component name |
| `*.spdx.json` | `name`, `documentNamespace`, and the root package name |
| `*.cdx.json` (Trivy) | `metadata.component.name` |

## Why no CLI flag was enough

Syft's `--source-name` fixes the root names in all three formats but leaves
`source.metadata.path` and the file component absolute. `cd`-ing into the target and passing a
relative path fixes those two but still leaves the file component and the HOME-derived config
dirs, and it breaks a relative output dir. Trivy has no `--source-name` equivalent at all.

So the four wrappers now rewrite the emitted JSON after the scan: the scanned repo path becomes
the project name, the target and output dirs become `.`, and `$HOME` becomes `~`. Only absolute
paths are rewritten — both the spelling passed in and its symlink-resolved form, since the tools
echo back whichever they were given. Syft additionally gets `--source-name` as belt-and-braces.
The scrub runs even when a scan fails, because a partial SBOM must not leak host paths either.

**Repo-relative paths are deliberately left intact.** The downstream parser groups Syft's maven
components by `syft:location:0:path` to reconstruct project boundaries, so stripping those would
break it. Verified unchanged.

## Verification

Two projects of the Zeppelin tree (155 and 8 components) plus a JavaScript one (178 components):
occurrences of the absolute host prefix went from 2–4 per file to **0 in every emitted file**,
component counts and the full set of `syft:location` values are byte-identical before and after,
all outputs still parse as JSON, and per-project failure handling returns the same exit codes.
Also checked with a relative target/output dir, a symlinked target spelling, a repo living under
HOME, and the no-subdirectory fallback.

## Known gaps, stated plainly

- **The `.ps1` twins mirror the same logic and have NOT been tested** — no Windows host and no
  pwsh on this machine. They additionally cover the raw, JSON-escaped and forward-slash spellings
  a Windows path can take in the JSON.
- The canonical 2026-08-19 SBOMs predate this fix and still carry the absolute path; they are not
  evidence the leak is unfixed.
- A full real-run grep over a freshly produced mission archive has not been re-run since the
  commit.

Touches only `bin/{syft,trivy}-wrapper.{sh,ps1}` — no jar, no `dist/`, so the npm package is
unaffected. Instrument-only, so this warrants a `-voyager` tag rather than a plain one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)